### PR TITLE
Rename repository, package, and namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 - 2019-09-02
+
+## 2.0.0 - 2020-03-08
+
+- Rename namespace from `Jahuty\Snippet` to `Jahuty\Jahuty`.
+- Rename repository and package name from `jahuty/snippets-php` to `jahuty/jahuty-php`.
+
+## 1.0.0 - 2019-09-02
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![CircleCI](https://circleci.com/gh/jahuty/snippets-php.svg?style=svg)](https://circleci.com/gh/jahuty/snippets-php)
 
-# snippets-php
+# jahuty-php
 
-Jahuty's PHP client.
+Welcome to [Jahuty's](https://www.jahuty.com) server-side PHP SDK!
 
 ## Installation
 
@@ -15,7 +15,7 @@ It should be installed via [Composer](https://getcomposer.org). To do so, add th
 ```javascript
 {
    "require": {
-       "jahuty/snippets-php": "^x"
+       "jahuty/jahuty-php": "^x"
    }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,9 @@
 {
-	"name": "jahuty/snippets-php",
-	"description": "Jahuty's PHP client",
+	"name": "jahuty/jahuty-php",
+	"description": "Jahuty's PHP SDK",
 	"keywords": [
 		"php",
-		"jahuty",
-		"snippets"
+		"jahuty"
 	],
 	"license": "MIT",
 	"authors": [
@@ -24,7 +23,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"Jahuty\\Snippet\\": "src/"
+			"Jahuty\\Jahuty\\": "src/"
 		}
 	}
 }

--- a/src/Data/Problem.php
+++ b/src/Data/Problem.php
@@ -4,7 +4,7 @@
  * @license    MIT
  */
 
-namespace Jahuty\Snippet\Data;
+namespace Jahuty\Jahuty\Data;
 
 use BadMethodCallException;
 

--- a/src/Data/Request.php
+++ b/src/Data/Request.php
@@ -4,7 +4,7 @@
  * @license    MIT
  */
 
-namespace Jahuty\Snippet\Data;
+namespace Jahuty\Jahuty\Data;
 
 use GuzzleHttp\Psr7\Request as Base;
 

--- a/src/Data/Snippet.php
+++ b/src/Data/Snippet.php
@@ -4,7 +4,7 @@
  * @license    MIT
  */
 
-namespace Jahuty\Snippet\Data;
+namespace Jahuty\Jahuty\Data;
 
 use BadMethodCallException;
 

--- a/src/Exception/NotOk.php
+++ b/src/Exception/NotOk.php
@@ -4,10 +4,10 @@
  * @license    MIT
  */
 
-namespace Jahuty\Snippet\Exception;
+namespace Jahuty\Jahuty\Exception;
 
 use Exception as PHPException;
-use Jahuty\Snippet\Data\Problem;
+use Jahuty\Jahuty\Data\Problem;
 
 /**
  * Thrown when the API responds with anything but 200.

--- a/src/Service/Get.php
+++ b/src/Service/Get.php
@@ -4,11 +4,11 @@
  * @license    MIT
  */
 
-namespace Jahuty\Snippet\Service;
+namespace Jahuty\Jahuty\Service;
 
 use GuzzleHttp\Client;
-use Jahuty\Snippet\Data\{Problem, Request, Snippet};
-use Jahuty\Snippet\Exception\NotOk;
+use Jahuty\Jahuty\Data\{Problem, Request, Snippet};
+use Jahuty\Jahuty\Exception\NotOk;
 
 class Get
 {

--- a/src/Snippet.php
+++ b/src/Snippet.php
@@ -4,12 +4,12 @@
  * @license    MIT
  */
 
-namespace Jahuty\Snippet;
+namespace Jahuty\Jahuty;
 
 use BadMethodCallException;
 use GuzzleHttp\Client;
-use Jahuty\Snippet\Data\Snippet as Resource;
-use Jahuty\Snippet\Service\Get;
+use Jahuty\Jahuty\Data\Snippet as Resource;
+use Jahuty\Jahuty\Service\Get;
 
 /**
  * A static wrapper for the memoized service and API key.

--- a/tests/Data/ProblemTest.php
+++ b/tests/Data/ProblemTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Jahuty\Snippet\Data;
+namespace Jahuty\Jahuty\Data;
 
 use BadMethodCallException;
 use PHPUnit\Framework\TestCase;

--- a/tests/Data/RequestTest.php
+++ b/tests/Data/RequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Jahuty\Snippet\Data;
+namespace Jahuty\Jahuty\Data;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Data/SnippetTest.php
+++ b/tests/Data/SnippetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Jahuty\Snippet\Data;
+namespace Jahuty\Jahuty\Data;
 
 use BadMethodCallException;
 use PHPUnit\Framework\TestCase;

--- a/tests/Exception/NotOkTest.php
+++ b/tests/Exception/NotOkTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Jahuty\Snippet\Exception;
+namespace Jahuty\Jahuty\Exception;
 
-use Jahuty\Snippet\Data\Problem;
+use Jahuty\Jahuty\Data\Problem;
 use PHPUnit\Framework\TestCase;
 
 class NotOkTest extends TestCase

--- a/tests/Service/GetTest.php
+++ b/tests/Service/GetTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Jahuty\Snippet\Service;
+namespace Jahuty\Jahuty\Service;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
-use Jahuty\Snippet\Data\Snippet;
-use Jahuty\Snippet\Exception\NotOk;
+use Jahuty\Jahuty\Data\Snippet;
+use Jahuty\Jahuty\Exception\NotOk;
 use JsonException;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/SnippetTest.php
+++ b/tests/SnippetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Jahuty\Snippet;
+namespace Jahuty\Jahuty;
 
 use BadMethodCallException;
 use PHPUnit\Framework\TestCase;
@@ -16,7 +16,7 @@ class SnippetTest extends TestCase
 
     public function testGet(): void
     {
-        Snippet::key('78e202009659616eceed79c01a75bfe9');
+        Snippet::key('kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc');
 
         $snippet = Snippet::get(1);
 


### PR DESCRIPTION
`Jahuty\Snippet` is too narrow, and we might need to add more objects in the namespace. Let's update the repository, package, and namespace to `jahuty-php` with namespace `Jahuty\Jahuty`.