### PR TITLE
Add jahuty object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.0 - 2020-03-08
+
+- Add `Jahuty\Jahuty\Jahuty` to store API key and current version number.
+- Remove `Jahuty\Jahuty\Snippet::key()` method.
 
 ## 2.0.0 - 2020-03-08
 
-- Rename namespace from `Jahuty\Snippet` to `Jahuty\Jahuty`.
-- Rename repository and package name from `jahuty/snippets-php` to `jahuty/jahuty-php`.
+- Change namespace from `Jahuty\Snippet` to `Jahuty\Jahuty`.
+- Change repository and package name from `jahuty/snippets-php` to `jahuty/jahuty-php`.
 
 ## 1.0.0 - 2019-09-02
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/jahuty/snippets-php.svg?style=svg)](https://circleci.com/gh/jahuty/snippets-php)
+[![CircleCI](https://circleci.com/gh/jahuty/jahuty-php.svg?style=svg)](https://circleci.com/gh/jahuty/jahuty-php)
 
 # jahuty-php
 
@@ -20,26 +20,74 @@ It should be installed via [Composer](https://getcomposer.org). To do so, add th
 }
 ```
 
-## Usage
+## Configuration
 
-Use the `key()` method to set your API key (ideally, once during startup):
+Configure `Jahuty` with your [API key](https://www.jahuty.com/docs/api#authentication) (ideally, once during startup):
 
 ```php
-Snippet::key('123abc456def789ghi');
+use Jahuty\Jahuty\Jahuty;
+
+Jahuty::setKey('YOUR_API_KEY');
 ```
 
-Then, use the `get()` method to retrieve a snippet (cast the return value to a `string`):
+## Usage
 
-```html
+With the API key set, you can use the `get()` method to retrieve a snippet:
+
+```php
+use Jahuty\Jahuty\Snippet;
+
+// retrieve the snippet...
+$snippet = Snippet::get(YOUR_SNIPPET_ID);
+
+// .. and, cast it to a string...
+(string)$snippet;
+
+// ...or, access its attributes
+$snippet->getId();
+$snippet->getContent();
+```
+
+In an HTML view:
+
+```html+php
+<?php
+use Jahuty\Jahuty\Jahuty;
+use Jahuty\Jahuty\Snippet;
+
+Jahuty::setKey('YOUR_API_KEY');
+?>
 <!doctype html>
 <html>
 <head>
-    <title>My awesome example</title>
+    <title>Awesome example</title>
 </head>
 <body>
-    <?php echo Snippet::get(123); ?>
+    <?php echo Snippet::get(YOUR_SNIPPET_ID); ?>
 </body>
 ```
+
+If you don't set your API key before calling `Snippet::get()`, a `BadMethodCallException` will be thrown. If an error occurs with [Jahuty's API](https://www.jahuty.com/docs/api), a `NotOk` exception will be thrown:
+
+```php
+use Jahuty\Jahuty\Snippet;
+use Jahuty\Jahuty\Exception\NotOk;
+
+try {
+  Snippet::(YOUR_SNIPPET_ID);
+} catch (BadMethodCallException $e) {
+  // hmm, did you call Jahuty::setKey() first?
+} catch (NotOk $e) {
+  // hmm, the API returned something besides 2xx status code
+  $problem = $e->getProblem();
+
+  echo $problem->getStatus();  // returns status code
+  echo $problem->getType();    // returns URL to more information
+  echo $problem->getDetail();  // returns description of error
+}
+```
+
+That's it!
 
 ## License
 
@@ -53,4 +101,4 @@ This library strives to adhere to the following standards:
 2. [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
 5. [Semantic Versioning 2.0](http://semver.org/spec/v2.0.0.html)
 
-If you spot an error, please let us know!
+If you spot an error, please open an issue or [let us know](https://www.jahuty.com/contacts/new)!

--- a/src/Jahuty.php
+++ b/src/Jahuty.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright  Jack Clayton <jack@jahuty.com>
+ * @license    MIT
+ */
+
+namespace Jahuty\Jahuty;
+
+/**
+ * Store version and key.
+ */
+class Jahuty
+{
+    public const VERSION = "3.0.0";
+
+    private static $key;
+
+    public static function getKey(): string
+    {
+        return self::$key;
+    }
+
+    public static function hasKey(): bool
+    {
+        return self::$key !== null;
+    }
+
+    public static function setKey(string $key): void
+    {
+        self::$key = $key;
+    }
+}

--- a/src/Snippet.php
+++ b/src/Snippet.php
@@ -12,31 +12,24 @@ use Jahuty\Jahuty\Data\Snippet as Resource;
 use Jahuty\Jahuty\Service\Get;
 
 /**
- * A static wrapper for the memoized service and API key.
+ * A static wrapper for the memoized service.
  */
 class Snippet
 {
     private static $get;
 
-    private static $key;
-
     public static function get(int $id): Resource
     {
-        if (self::$key === null) {
+        if (!Jahuty::hasKey()) {
             throw new BadMethodCallException(
-                "API key not set. Did you call Snippet::key()?"
+                "API key not set. Did you call Jahuty::setKey()?"
             );
         }
 
         if (self::$get === null) {
-            self::$get = new Get(self::$key, new Client());
+            self::$get = new Get(Jahuty::getKey(), new Client());
         }
 
         return (self::$get)($id);
-    }
-
-    public static function key(string $key): void
-    {
-        self::$key = $key;
     }
 }

--- a/tests/JahutyTest.php
+++ b/tests/JahutyTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Jahuty\Jahuty;
+
+use BadMethodCallException;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class JahutyTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->resetJahuty();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetJahuty();
+    }
+
+    public function testgetKey(): void
+    {
+        $key = "foo";
+
+        Jahuty::setKey($key);
+
+        $this->assertEquals($key, Jahuty::getKey());
+    }
+
+    public function testHasKeyReturnsFalseIfKeyDoesNotExist(): void
+    {
+        $this->assertFalse(Jahuty::hasKey());
+    }
+
+    public function testHasKeyReturnsTrueIfKeyDoesExist(): void
+    {
+        Jahuty::setKey("foo");
+
+        $this->assertTrue(Jahuty::hasKey());
+    }
+
+    public function testSetKey(): void
+    {
+        $this->assertNull(Jahuty::setKey("foo"));
+    }
+
+    /**
+     * Reset Jahuty's static state between tests.
+     *
+     * PHPUnit 9.0+ recommends explicitly resetting the values of static
+     * properties between tests in setup() and tearDown() methods, because the
+     * @backupStaticAttributes annotation (and XML configuration setting of the
+     * same name) don't work on newly loaded classes.
+     *
+     * @see  https://phpunit.readthedocs.io/en/9.0/fixtures.html
+     */
+    private function resetJahuty(): void
+    {
+        $reflection = new ReflectionClass(Jahuty::class);
+
+        $key = $reflection->getProperty('key');
+        $key->setAccessible(true);
+        $key->setValue(null, null);
+        $key->setAccessible(false);
+    }
+}

--- a/tests/JahutyTest.php
+++ b/tests/JahutyTest.php
@@ -2,7 +2,6 @@
 
 namespace Jahuty\Jahuty;
 
-use BadMethodCallException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 

--- a/tests/SnippetTest.php
+++ b/tests/SnippetTest.php
@@ -3,6 +3,7 @@
 namespace Jahuty\Jahuty;
 
 use BadMethodCallException;
+use Jahuty\Jahuty\Jahuty;
 use PHPUnit\Framework\TestCase;
 
 class SnippetTest extends TestCase
@@ -16,7 +17,7 @@ class SnippetTest extends TestCase
 
     public function testGet(): void
     {
-        Snippet::key('kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc');
+        Jahuty::setKey('kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc');
 
         $snippet = Snippet::get(1);
 


### PR DESCRIPTION
Let's move the API key handling from the `Snippet` object to the `Jahuty` object, a breaking change.