### PR TITLE
Change params to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.1 - 2020-03-15
+
+- Change snippet parameters to JSON query string parameter (e.g., `params={"foo":"bar"}`) from serialized query string parameter (e.g.,`params[foo]=bar`).
+
 ## 3.1.0 - 2020-03-13
 
 - Add snippet parameters.

--- a/src/Service/Get.php
+++ b/src/Service/Get.php
@@ -21,9 +21,15 @@ class Get
 
     public function __invoke(int $id, array $params = []): Snippet
     {
-        $response = $this->client->request('GET', "snippets/$id", ['query' => [
-            'params' => $params
-        ]]);
+        $options = [];
+
+        if ($params) {
+            $options['query'] = [
+                'params' => json_encode($params, JSON_THROW_ON_ERROR)
+            ];
+        }
+
+        $response = $this->client->request('GET', "snippets/$id", $options);
 
         $payload = $response->getBody();
         $payload = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
Let's change snippet parameters to a URL-encoded JSON string. This avoids the complications of how different languages serialize the same array into query string parameters. 