### PR TITLE
4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change the optional second argument of `render()` from an array of `params` to an options array with a `params` key.
 - Rename `Data\Snippet` to `Data\Render`.
 - Remove `id` attribute from `Data\Render`.
+- Change API endpoint from `snippets/:id` to `snippets/:id/render`.
 
 ## 3.1.1 - 2020-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rename `Get` service to `Render`.
 - Rename `Snippet::get` to `Snippet::render`.
+- Change the optional second argument of `render()` from an array of `params` to an options array with a `params` key.
 
 ## 3.1.1 - 2020-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 4.0.0 - 2020-07-04
 
 - Rename `Get` service to `Render`.
+- Rename `Snippet::get` to `Snippet::render`.
 
 ## 3.1.1 - 2020-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0 - 2020-07-04
+
+- Rename `Get` service to `Render`.
+
 ## 3.1.1 - 2020-03-15
 
 - Change snippet parameters to JSON query string parameter (e.g., `params={"foo":"bar"}`) from serialized query string parameter (e.g.,`params[foo]=bar`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## 4.0.0 - 2020-07-04
 
-- Rename `Get` service to `Render`.
+- Rename `Serivce\Get` to `Service\Render`.
 - Rename `Snippet::get` to `Snippet::render`.
 - Change the optional second argument of `render()` from an array of `params` to an options array with a `params` key.
 - Rename `Data\Snippet` to `Data\Render`.
+- Remove `id` attribute from `Data\Render`.
 
 ## 3.1.1 - 2020-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 4.0.0 - 2020-07-04
 
 - Rename `Get` service to `Render`.
 - Rename `Snippet::get` to `Snippet::render`.
 - Change the optional second argument of `render()` from an array of `params` to an options array with a `params` key.
+- Rename `Data\Snippet` to `Data\Render`.
 
 ## 3.1.1 - 2020-03-15
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ With the API key set, you can use the `get()` method to retrieve a snippet:
 ```php
 use Jahuty\Jahuty\Snippet;
 
-// retrieve the snippet...
-$snippet = Snippet::get(YOUR_SNIPPET_ID);
+// render the snippet...
+$snippet = Snippet::render(YOUR_SNIPPET_ID);
 
 // .. and, cast it to a string...
 (string)$snippet;

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ use Jahuty\Jahuty\Jahuty;
 Jahuty::setKey('YOUR_API_KEY');
 ```
 
-With the API key set, you can use the `get()` method to retrieve a snippet:
+With the API key set, you can use the `render()` method to retrieve a snippet:
 
 ```php
 use Jahuty\Jahuty\Snippet;
@@ -41,8 +41,7 @@ $snippet = Snippet::render(YOUR_SNIPPET_ID);
 // .. and, cast it to a string...
 (string)$snippet;
 
-// ...or, access its attributes
-$snippet->getId();
+// ...or, access its content
 $snippet->getContent();
 ```
 
@@ -60,7 +59,7 @@ Jahuty::setKey('YOUR_API_KEY');
     <title>Awesome example</title>
 </head>
 <body>
-    <?php echo Snippet::get(YOUR_SNIPPET_ID); ?>
+    <?php echo Snippet::render(YOUR_SNIPPET_ID); ?>
 </body>
 ```
 
@@ -71,7 +70,7 @@ You can [pass parameters](https://www.jahuty.com/docs/passing-a-parameter) into 
 ```php
 use Jahuty\Jahuty\Snippet;
 
-$snippet = Snippet::get(YOUR_SNIPPET_ID, [
+$snippet = Snippet::render(YOUR_SNIPPET_ID, [
   'params' => [
     'foo'   => 'bar',
     'baz'   => ['qux', 'quux'],
@@ -94,7 +93,7 @@ The parameters above would be equivalent to [assigning the variables](https://ww
 
 ## Errors
 
-If you don't set your API key before calling `Snippet::get()`, a `BadMethodCallException` will be thrown, and if [Jahuty's API](https://www.jahuty.com/docs/api) returns any status code other than `2xx`, a `NotOk` exception will be thrown:
+If you don't set your API key before calling `Snippet::render()`, a `BadMethodCallException` will be thrown, and if [Jahuty's API](https://www.jahuty.com/docs/api) returns any status code other than `2xx`, a `NotOk` exception will be thrown:
 
 ```php
 use Jahuty\Jahuty\Snippet;

--- a/README.md
+++ b/README.md
@@ -66,17 +66,19 @@ Jahuty::setKey('YOUR_API_KEY');
 
 ## Parameters
 
-You can [pass parameters](https://www.jahuty.com/docs/passing-a-parameter) into your snippet with an optional second argument:
+You can [pass parameters](https://www.jahuty.com/docs/passing-a-parameter) into your snippet using the options associative array:
 
 ```php
 use Jahuty\Jahuty\Snippet;
 
 $snippet = Snippet::get(YOUR_SNIPPET_ID, [
-  'foo'   => 'bar',
-  'baz'   => ['qux', 'quux'],
-  'corge' => [
-    'grault' => [
-      'garply' => 'waldo'
+  'params' => [
+    'foo'   => 'bar',
+    'baz'   => ['qux', 'quux'],
+    'corge' => [
+      'grault' => [
+        'garply' => 'waldo'
+      ]
     ]
   ]
 ]);

--- a/README.md
+++ b/README.md
@@ -30,19 +30,19 @@ use Jahuty\Jahuty\Jahuty;
 Jahuty::setKey('YOUR_API_KEY');
 ```
 
-With the API key set, you can use the `render()` method to retrieve a snippet:
+With the API key set, you can use the `Snippet::render()` method to render a snippet:
 
 ```php
 use Jahuty\Jahuty\Snippet;
 
 // render the snippet...
-$snippet = Snippet::render(YOUR_SNIPPET_ID);
+$render = Snippet::render(YOUR_SNIPPET_ID);
 
 // .. and, cast it to a string...
-(string)$snippet;
+(string)$render;
 
 // ...or, access its content
-$snippet->getContent();
+$render->getContent();
 ```
 
 In an HTML view:
@@ -65,12 +65,12 @@ Jahuty::setKey('YOUR_API_KEY');
 
 ## Parameters
 
-You can [pass parameters](https://www.jahuty.com/docs/passing-a-parameter) into your snippet using the options associative array:
+You can [pass parameters](https://www.jahuty.com/docs/passing-a-parameter) into your snippet using the optional options hash and the `params` key:
 
 ```php
 use Jahuty\Jahuty\Snippet;
 
-$snippet = Snippet::render(YOUR_SNIPPET_ID, [
+$render = Snippet::render(YOUR_SNIPPET_ID, [
   'params' => [
     'foo'   => 'bar',
     'baz'   => ['qux', 'quux'],
@@ -100,7 +100,7 @@ use Jahuty\Jahuty\Snippet;
 use Jahuty\Jahuty\Exception\NotOk;
 
 try {
-  Snippet::render(YOUR_SNIPPET_ID);
+  $render = Snippet::render(YOUR_SNIPPET_ID);
 } catch (BadMethodCallException $e) {
   // hmm, did you call Jahuty::setKey() first?
 } catch (NotOk $e) {

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ use Jahuty\Jahuty\Snippet;
 use Jahuty\Jahuty\Exception\NotOk;
 
 try {
-  Snippet::(YOUR_SNIPPET_ID);
+  Snippet::render(YOUR_SNIPPET_ID);
 } catch (BadMethodCallException $e) {
   // hmm, did you call Jahuty::setKey() first?
 } catch (NotOk $e) {

--- a/src/Data/Render.php
+++ b/src/Data/Render.php
@@ -8,7 +8,7 @@ namespace Jahuty\Jahuty\Data;
 
 use BadMethodCallException;
 
-class Snippet
+class Render
 {
     private $content;
 
@@ -20,7 +20,7 @@ class Snippet
         $this->content = $content;
     }
 
-    public static function from(array $payload): Snippet
+    public static function from(array $payload): Render
     {
         if (!array_key_exists('id', $payload)) {
             throw new BadMethodCallException("Key 'id' does not exist");
@@ -30,7 +30,7 @@ class Snippet
             throw new BadMethodCallException("Key 'content' does not exist");
         }
 
-        return new Snippet($payload['id'], $payload['content']);
+        return new Render($payload['id'], $payload['content']);
     }
 
     public function __toString(): string

--- a/src/Data/Render.php
+++ b/src/Data/Render.php
@@ -12,25 +12,18 @@ class Render
 {
     private $content;
 
-    private $id;
-
-    public function __construct(int $id, string $content)
+    public function __construct(string $content)
     {
-        $this->id      = $id;
         $this->content = $content;
     }
 
     public static function from(array $payload): Render
     {
-        if (!array_key_exists('id', $payload)) {
-            throw new BadMethodCallException("Key 'id' does not exist");
-        }
-
         if (!array_key_exists('content', $payload)) {
             throw new BadMethodCallException("Key 'content' does not exist");
         }
 
-        return new Render($payload['id'], $payload['content']);
+        return new Render($payload['content']);
     }
 
     public function __toString(): string
@@ -41,10 +34,5 @@ class Render
     public function getContent(): string
     {
         return $this->content;
-    }
-
-    public function getId(): int
-    {
-        return $this->id;
     }
 }

--- a/src/Service/Render.php
+++ b/src/Service/Render.php
@@ -19,17 +19,17 @@ class Render
         $this->client = $client;
     }
 
-    public function __invoke(int $id, array $params = []): Snippet
+    public function __invoke(int $id, array $options = []): Snippet
     {
-        $options = [];
+        $settings = [];
 
-        if ($params) {
-            $options['query'] = [
-                'params' => json_encode($params, JSON_THROW_ON_ERROR)
+        if (array_key_exists('params', $options)) {
+            $settings['query'] = [
+                'params' => json_encode($options['params'], JSON_THROW_ON_ERROR)
             ];
         }
 
-        $response = $this->client->request('GET', "snippets/$id", $options);
+        $response = $this->client->request('GET', "snippets/$id", $settings);
 
         $payload = $response->getBody();
         $payload = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);

--- a/src/Service/Render.php
+++ b/src/Service/Render.php
@@ -29,7 +29,7 @@ class Render
             ];
         }
 
-        $response = $this->client->request('GET', "snippets/$id", $settings);
+        $response = $this->client->request('GET', "snippets/$id/render", $settings);
 
         $payload = $response->getBody();
         $payload = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);

--- a/src/Service/Render.php
+++ b/src/Service/Render.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Client;
 use Jahuty\Jahuty\Data\{Problem, Request, Snippet};
 use Jahuty\Jahuty\Exception\NotOk;
 
-class Get
+class Render
 {
     private $client;
 

--- a/src/Service/Render.php
+++ b/src/Service/Render.php
@@ -7,7 +7,7 @@
 namespace Jahuty\Jahuty\Service;
 
 use GuzzleHttp\Client;
-use Jahuty\Jahuty\Data\{Problem, Request, Snippet};
+use Jahuty\Jahuty\Data\{Problem, Render as Resource};
 use Jahuty\Jahuty\Exception\NotOk;
 
 class Render
@@ -19,7 +19,7 @@ class Render
         $this->client = $client;
     }
 
-    public function __invoke(int $id, array $options = []): Snippet
+    public function __invoke(int $id, array $options = []): Resource
     {
         $settings = [];
 
@@ -38,6 +38,6 @@ class Render
             throw new NotOk(Problem::from($payload));
         }
 
-        return Snippet::from($payload);
+        return Resource::from($payload);
     }
 }

--- a/src/Snippet.php
+++ b/src/Snippet.php
@@ -17,7 +17,7 @@ class Snippet
 {
     private static $get;
 
-    public static function get(int $id, array $params = []): Resource
+    public static function render(int $id, array $params = []): Resource
     {
         if (!Jahuty::hasKey()) {
             throw new BadMethodCallException(

--- a/src/Snippet.php
+++ b/src/Snippet.php
@@ -8,7 +8,7 @@ namespace Jahuty\Jahuty;
 
 use BadMethodCallException;
 use Jahuty\Jahuty\Data\Snippet as Resource;
-use Jahuty\Jahuty\Service\Get;
+use Jahuty\Jahuty\Service\Render;
 
 /**
  * A static wrapper for the memoized service.
@@ -26,7 +26,7 @@ class Snippet
         }
 
         if (self::$get === null) {
-            self::$get = new Get(Jahuty::getClient());
+            self::$get = new Render(Jahuty::getClient());
         }
 
         return (self::$get)($id, $params);

--- a/src/Snippet.php
+++ b/src/Snippet.php
@@ -7,7 +7,7 @@
 namespace Jahuty\Jahuty;
 
 use BadMethodCallException;
-use Jahuty\Jahuty\Data\Snippet as Resource;
+use Jahuty\Jahuty\Data\Render as Resource;
 use Jahuty\Jahuty\Service\Render;
 
 /**

--- a/src/Snippet.php
+++ b/src/Snippet.php
@@ -17,7 +17,7 @@ class Snippet
 {
     private static $get;
 
-    public static function render(int $id, array $params = []): Resource
+    public static function render(int $id, array $options = []): Resource
     {
         if (!Jahuty::hasKey()) {
             throw new BadMethodCallException(
@@ -29,6 +29,6 @@ class Snippet
             self::$get = new Render(Jahuty::getClient());
         }
 
-        return (self::$get)($id, $params);
+        return (self::$get)($id, $options);
     }
 }

--- a/tests/Data/SnippetTest.php
+++ b/tests/Data/SnippetTest.php
@@ -11,16 +11,7 @@ class RenderTest extends TestCase
 
     public function setUp(): void
     {
-        $this->payload = ['id' => 1, 'content' => 'foo'];
-    }
-
-    public function testFromThrowsExceptionIfIdDoesNotExist(): void
-    {
-        $this->expectException(BadMethodCallException::class);
-
-        unset($this->payload['id']);
-
-        Render::from($this->payload);
+        $this->payload = ['content' => 'foo'];
     }
 
     public function testFromThrowsExceptionIfContentsDoesNotExist(): void
@@ -34,7 +25,7 @@ class RenderTest extends TestCase
 
     public function testFrom(): void
     {
-        $expected = new Render(1, 'foo');
+        $expected = new Render('foo');
         $actual   = Render::from($this->payload);
 
         $this->assertEquals($expected, $actual);
@@ -42,16 +33,11 @@ class RenderTest extends TestCase
 
     public function testGetContent(): void
     {
-        $this->assertEquals('foo', (new Render(1, 'foo'))->getContent());
-    }
-
-    public function testGetId(): void
-    {
-        $this->assertEquals(1, (new Render(1, 'foo'))->getId());
+        $this->assertEquals('foo', (new Render('foo'))->getContent());
     }
 
     public function testToString(): void
     {
-        $this->assertEquals('foo', (string)new Render(1, 'foo'));
+        $this->assertEquals('foo', (string)new Render('foo'));
     }
 }

--- a/tests/Data/SnippetTest.php
+++ b/tests/Data/SnippetTest.php
@@ -5,7 +5,7 @@ namespace Jahuty\Jahuty\Data;
 use BadMethodCallException;
 use PHPUnit\Framework\TestCase;
 
-class SnippetTest extends TestCase
+class RenderTest extends TestCase
 {
     private $payload;
 
@@ -20,7 +20,7 @@ class SnippetTest extends TestCase
 
         unset($this->payload['id']);
 
-        Snippet::from($this->payload);
+        Render::from($this->payload);
     }
 
     public function testFromThrowsExceptionIfContentsDoesNotExist(): void
@@ -29,29 +29,29 @@ class SnippetTest extends TestCase
 
         unset($this->payload['content']);
 
-        Snippet::from($this->payload);
+        Render::from($this->payload);
     }
 
     public function testFrom(): void
     {
-        $expected = new Snippet(1, 'foo');
-        $actual   = Snippet::from($this->payload);
+        $expected = new Render(1, 'foo');
+        $actual   = Render::from($this->payload);
 
         $this->assertEquals($expected, $actual);
     }
 
     public function testGetContent(): void
     {
-        $this->assertEquals('foo', (new Snippet(1, 'foo'))->getContent());
+        $this->assertEquals('foo', (new Render(1, 'foo'))->getContent());
     }
 
     public function testGetId(): void
     {
-        $this->assertEquals(1, (new Snippet(1, 'foo'))->getId());
+        $this->assertEquals(1, (new Render(1, 'foo'))->getId());
     }
 
     public function testToString(): void
     {
-        $this->assertEquals('foo', (string)new Snippet(1, 'foo'));
+        $this->assertEquals('foo', (string)new Render(1, 'foo'));
     }
 }

--- a/tests/Service/RenderTest.php
+++ b/tests/Service/RenderTest.php
@@ -9,7 +9,7 @@ use Jahuty\Jahuty\Exception\NotOk;
 use JsonException;
 use PHPUnit\Framework\TestCase;
 
-class GetTest extends TestCase
+class RenderTest extends TestCase
 {
     public function testInvokeThrowsExceptionIfResponseInvalid(): void
     {
@@ -22,7 +22,7 @@ class GetTest extends TestCase
         $client = $this->createMock(Client::class);
         $client->method('request')->willReturn($response);
 
-        $sut = new Get($client);
+        $sut = new Render($client);
 
         $sut(1);
     }
@@ -41,7 +41,7 @@ class GetTest extends TestCase
         $client = $this->createMock(Client::class);
         $client->method('request')->willReturn($response);
 
-        $sut = new Get($client);
+        $sut = new Render($client);
 
         $sut(1);
     }
@@ -58,7 +58,7 @@ class GetTest extends TestCase
         $client = $this->createMock(Client::class);
         $client->method('request')->willReturn($response);
 
-        $sut = new Get($client);
+        $sut = new Render($client);
 
         $expected = new Snippet(1, 'foo');
         $actual   = $sut(1);

--- a/tests/Service/RenderTest.php
+++ b/tests/Service/RenderTest.php
@@ -4,7 +4,7 @@ namespace Jahuty\Jahuty\Service;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
-use Jahuty\Jahuty\Data\Snippet;
+use Jahuty\Jahuty\Data\Render as Resource;
 use Jahuty\Jahuty\Exception\NotOk;
 use JsonException;
 use PHPUnit\Framework\TestCase;
@@ -60,7 +60,7 @@ class RenderTest extends TestCase
 
         $sut = new Render($client);
 
-        $expected = new Snippet(1, 'foo');
+        $expected = new Resource(1, 'foo');
         $actual   = $sut(1);
 
         $this->assertEquals($expected, $actual);

--- a/tests/Service/RenderTest.php
+++ b/tests/Service/RenderTest.php
@@ -49,7 +49,7 @@ class RenderTest extends TestCase
     public function testInvokeIfOk(): void
     {
         // mock a valid response
-        $body = '{"id": 1, "content":"foo"}';
+        $body = '{"content":"foo"}';
 
         $response = $this->createMock(Response::class);
         $response->method('getBody')->willReturn($body);
@@ -60,7 +60,7 @@ class RenderTest extends TestCase
 
         $sut = new Render($client);
 
-        $expected = new Resource(1, 'foo');
+        $expected = new Resource('foo');
         $actual   = $sut(1);
 
         $this->assertEquals($expected, $actual);

--- a/tests/SnippetTest.php
+++ b/tests/SnippetTest.php
@@ -12,14 +12,14 @@ class SnippetTest extends TestCase
     {
         $this->expectException(BadMethodCallException::class);
 
-        Snippet::get(1);
+        Snippet::render(1);
     }
 
     public function testGet(): void
     {
         Jahuty::setKey('kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc');
 
-        $snippet = Snippet::get(1);
+        $snippet = Snippet::render(1);
 
         $this->assertEquals(1, $snippet->getId());
         $this->assertEquals('This is my first snippet!', $snippet->getContent());

--- a/tests/SnippetTest.php
+++ b/tests/SnippetTest.php
@@ -21,7 +21,6 @@ class SnippetTest extends TestCase
 
         $snippet = Snippet::render(1);
 
-        $this->assertEquals(1, $snippet->getId());
         $this->assertEquals('This is my first snippet!', $snippet->getContent());
     }
 }


### PR DESCRIPTION
Lots of breaking changes that follow our shift in logic from _retrieving_ snippets to _rendering_ them:

- Rename `Service\Get` to `Service\Render`. 
- Rename `Snippet::get` to `Snippet::render`.
- Change the optional second argument of `render()` from an array of `params` to an options array with a `params` key.
- Rename `Data\Snippet` to `Data\Render`.
- Remove `id` attribute from `Data\Render`.
- Change API endpoint from `snippets/:id` to `snippets/:id/render`.