### PR TITLE
Add caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.1.0 - 2020-12-26
+
+- Add a second, optional parameter to `Jahuty\Client`, an options array with support for the following options: `cache`, a `CacheInterface` implementation); `ttl`, a `null`, `int`, or `DateInterval` SDK-wide time-to-live; and, `base_uri`, the base URI for API requests (useful for testing).
+- Add `fetch()` to `Jahuty\Client`, which checks the cache before requesting an action.
+- Add `Jahuty\Cache\Memory`, a PSR-16 compliant in-memory cache adapter.
+- Change `Jahuty\Client` to default to the in-memory cache, if no `cache` is configured.
+- Move system tests to a separate test case, and improve the testing of `Jahuty\Client`.
+
 ## 5.0.0 - 2020-12-23
 
 - Reduce root namespace from `Jahuty\Jahuty` to `Jahuty`.
 - Change from a static-based architecture (e.g., `\Jahuty\Jahuty\Snippet::render(1)`) to an instance-based one (e.g., `$jahuty->snippets->render(1)`) to make the library easier to develop, test, and use.
 - Fix links in `README`.
+- Add code coverage analysis.
 
 ## 4.0.0 - 2020-07-04
 

--- a/README.md
+++ b/README.md
@@ -75,29 +75,30 @@ The parameters above would be equivalent to [assigning the variables](https://do
 
 ## Caching
 
-Caching allows you to balance a snippet's retrieval speed and refresh rate. When caching is enabled and a valid cache entry exists, this library can use the cached version instead of requesting the latest version from the API. With caching, you can tune your application's performance based on your content's stability and traffic.
+Caching renders allows you to tune your application's response time based on your content's stability and traffic. By caching a render for a period of time, you can decrease the number of synchronous requests to Jahuty's API.
 
 ### Caching in memory (default)
 
-By default, Jahuty uses an in-memory cache to avoid requesting the same snippet and parameter combination more than once during the request's lifecycle. For example:
+By default, Jahuty uses an in-memory cache to avoid requesting the same render more than once during the original request's lifecycle. For example:
 
 ```php
 $jahuty = new \Jahuty\Client('YOUR_API_KEY');
 
-// This call sends an API request. The result is cached in memory and returned.
+// This call sends a synchronous API request; caches the result in memory; and,
+// returns it to the caller.
 $render1 = $jahuty->snippets->render(YOUR_SNIPPET_ID);
 
 // This call skips sending an API request and uses the cached value instead.
 $render2 = $jahuty->snippets->render(YOUR_SNIPPET_ID);
 ```
 
-This in-memory cache only persists for the duration of the original request, however. At the end of the request's lifecycle, the cache will be discarded.
+The in-memory cache only persists for the duration of the original request. At the end of the request's lifecycle, the cache will be discarded. To store renders across requests, you need a persistent cache.
 
 ### Caching persistently
 
-A persistent cache, on the other hand, allows content to be cached across multiple requests. This reduces the number of network requests and increases your application's performance.
+A persistent cache allows renders to be cached across multiple requests. This reduces the number of synchronous network requests to Jahuty's API, and thereby increases your application's average response time.
 
-To configure Jahuty to use your persistent cache, pass a [PSR-16](https://www.php-fig.org/psr/psr-16/) `CacheInterface` implementation to the client via its `cache` configuration option:
+To configure Jahuty to use your persistent cache, pass a [PSR-16](https://www.php-fig.org/psr/psr-16/) `CacheInterface` implementation to the client via the `cache` configuration option:
 
 ```php
 $jahuty = new \Jahuty\Client('YOUR_API_KEY', ['cache' => $cache]);
@@ -105,36 +106,35 @@ $jahuty = new \Jahuty\Client('YOUR_API_KEY', ['cache' => $cache]);
 
 ### Expiring
 
-There are three methods for configuring the amount of time between when a snippet is stored and when it's considered stale (aka, Time to Live or TTL). From lowest-to-highest precedence, they are:
+There are three methods for configuring a render's Time to Live (TTL). From lowest-to-highest precedence, they are:
 
-1. _Configuring your caching implementation_. Many implementations allow you to set a default TTL, which this library will use by default.
-1. _Configuring this library's default TTL_. You can pass an integer number of seconds or a `DateInterval` instance via the client's `ttl` configuration option for all requests:
+1. _Configuring your caching implementation_. Many cache implementations allow you to set a default TTL, which this library will use by default.
+1. _Configuring this library's default TTL_. You can pass an integer number of seconds or a `DateInterval` via the client's `ttl` configuration option. This TTL will be used for all renders:
 ```php
-// cache all snippets for sixty seconds
+// cache all renders for sixty seconds
 $jahuty = new \Jahuty\Client('YOUR_API_KEY', [
   'cache' => $cache,
   'ttl'   => 60
 ]);
 ```
-1. _Configuring a snippet's `ttl`_. You can pass an integer number of seconds or a `DateInterval` instance via the render's `ttl` option for a specific snippet and parameter combination:
+1. _Configuring a render's `ttl`_. You can pass an integer number of seconds or a `DateInterval` instance via the render's `ttl` option for a specific render:
 ```php
 $jahuty = new \Jahuty\Client('YOUR_API_KEY', ['cache' => $cache]);
 
-// cache this snippet for sixty seconds
+// cache this render for sixty seconds
 $render = $jahuty->snippets->render(1, ['ttl' => 60]);
 ```
 
 ### Disabling caching
 
-You can disable caching, even the default in-memory caching, by passing a `ttl` of zero (`0`) via any of the methods described above. For example:
+You can disable caching, even the default in-memory caching, by passing a `ttl` of zero (`0`) or a negative integer (e.g., `-1`) via any of the methods described above. For example:
 
 ```php
 // disable all caching
 $jahuty1 = new \Jahuty\Client('YOUR_API_KEY', ['ttl' => 0]);
 
-// use the default in-memory caching...
 $jahuty2 = new \Jahuty\Client('YOUR_API_KEY');
-// ... but disable caching for this snippet
+// disable caching for this render
 $jahuty2->snippets->render(1, ['ttl' => 0]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,71 @@ The parameters above would be equivalent to [assigning the variables](https://do
 {% assign foo = "bar" %}
 ```
 
+## Caching
+
+Caching allows you to balance a snippet's retrieval speed and refresh rate. When caching is enabled and a valid cache entry exists, this library can use the cached version instead of requesting the latest version from the API. With caching, you can tune your application's performance based on your content's stability and traffic.
+
+### Caching in memory (default)
+
+By default, Jahuty uses an in-memory cache to avoid requesting the same snippet and parameter combination more than once during the request's lifecycle. For example:
+
+```php
+$jahuty = new \Jahuty\Client('YOUR_API_KEY');
+
+// This call sends an API request. The result is cached in memory and returned.
+$render1 = $jahuty->snippets->render(YOUR_SNIPPET_ID);
+
+// This call skips sending an API request and uses the cached value instead.
+$render2 = $jahuty->snippets->render(YOUR_SNIPPET_ID);
+```
+
+This in-memory cache only persists for the duration of the original request, however. At the end of the request's lifecycle, the cache will be discarded.
+
+### Caching persistently
+
+A persistent cache, on the other hand, allows content to be cached across multiple requests. This reduces the number of network requests and increases your application's performance.
+
+To configure Jahuty to use your persistent cache, pass a [PSR-16](https://www.php-fig.org/psr/psr-16/) `CacheInterface` implementation to the client via its `cache` configuration option:
+
+```php
+$jahuty = new \Jahuty\Client('YOUR_API_KEY', ['cache' => $cache]);
+```
+
+### Expiring
+
+There are three methods for configuring the amount of time between when a snippet is stored and when it's considered stale (aka, Time to Live or TTL). From lowest-to-highest precedence, they are:
+
+1. _Configuring your caching implementation_. Many implementations allow you to set a default TTL, which this library will use by default.
+1. _Configuring this library's default TTL_. You can pass an integer number of seconds or a `DateInterval` instance via the client's `ttl` configuration option for all requests:
+```php
+// cache all snippets for sixty seconds
+$jahuty = new \Jahuty\Client('YOUR_API_KEY', [
+  'cache' => $cache,
+  'ttl'   => 60
+]);
+```
+1. _Configuring a snippet's `ttl`_. You can pass an integer number of seconds or a `DateInterval` instance via the render's `ttl` option for a specific snippet and parameter combination:
+```php
+$jahuty = new \Jahuty\Client('YOUR_API_KEY', ['cache' => $cache]);
+
+// cache this snippet for sixty seconds
+$render = $jahuty->snippets->render(1, ['ttl' => 60]);
+```
+
+### Disabling caching
+
+You can disable caching, even the default in-memory caching, by passing a `ttl` of zero (`0`) via any of the methods described above. For example:
+
+```php
+// disable all caching
+$jahuty1 = new \Jahuty\Client('YOUR_API_KEY', ['ttl' => 0]);
+
+// use the default in-memory caching...
+$jahuty2 = new \Jahuty\Client('YOUR_API_KEY');
+// ... but disable caching for this snippet
+$jahuty2->snippets->render(1, ['ttl' => 0]);
+```
+
 ## Errors
 
 If [Jahuty's API](https://docs.jahuty.com/api) returns any status code other than `2xx`, a `Jahuty\Exception\Error` will be thrown:

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "php": "^7.3 || ~8.0.0",
     "psr/http-factory": "^1",
     "psr/http-message": "^1",
+    "psr/simple-cache": "^1",
     "guzzlehttp/guzzle": "^6.3"
   },
   "require-dev": {

--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -3,6 +3,7 @@
 namespace Jahuty\Api;
 
 use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\BadResponseException;
 use Psr\Http\Message\{
     RequestInterface as Request,
     ResponseInterface as Response
@@ -31,7 +32,12 @@ class Client
             $this->client = new HttpClient(['headers' => $this->headers]);
         }
 
-        return $this->client->send($request);
+        try {
+            return $this->client->send($request);
+        } catch (BadResponseException $e) {
+            // We'll handle client and server errors.
+            return $e->getResponse();
+        }
     }
 
     private function setHeaders(string $key): void

--- a/src/Cache/Manager.php
+++ b/src/Cache/Manager.php
@@ -52,8 +52,25 @@ class Manager
         return $resource;
     }
 
+    /**
+     * Returns a cache key for a resource, id, and params combination.
+     *
+     * I use an md5 hash to allow inputs of any length and outputs of a known
+     * (and valid) length. According to PSR-16, valid keys are, "the characters
+     * A-Z, a-z, 0-9, _, and . in any order in UTF-8 encoding and a length of up
+     * to 64 characters."
+     */
     private function getKey(Show $action): string
     {
-        return "jahuty_{$action->getResource()}_{$action->getId()}";
+        $segments = [
+             'jahuty',
+             $action->getResource(),
+             $action->getId(),
+             json_encode($action->getParams(), JSON_THROW_ON_ERROR)
+        ];
+
+        $key = implode('\\', $segments);
+
+        return md5($key);
     }
 }

--- a/src/Cache/Manager.php
+++ b/src/Cache/Manager.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Jahuty\Cache;
+
+use Jahuty\Action\{Action, Show};
+use Jahuty\Client;
+use Jahuty\Resource\Resource;
+use Psr\SimpleCache\CacheInterface as Cache;
+
+class Manager
+{
+    private $cache;
+
+    private $client;
+
+    private $ttl;
+
+    public function __construct(Client $client, Cache $cache, $ttl = null)
+    {
+        if (
+            $ttl !== null &&
+            $ttl !== (int)$ttl &&
+            !($ttl instanceof \DateInterval)
+        ) {
+            throw new \InvalidArgumentException(
+                "Parameter three, ttl, must be null, integer, or DateInterval"
+            );
+        }
+
+        $this->client = $client;
+        $this->cache  = $cache;
+        $this->ttl    = $ttl;
+    }
+
+    public function fetch(Action $action, $ttl = null): Resource
+    {
+        if (
+            $ttl !== null &&
+            $ttl !== (int)$ttl &&
+            !($ttl instanceof \DateInterval)
+        ) {
+            throw new \InvalidArgumentException(
+                "Parameter two, ttl, must be null, integer, or DateInterval"
+            );
+        }
+
+        $key = $this->getKey($action);
+
+        if (null === ($resource = $this->cache->get($key))) {
+            $resource = $this->client->request($action);
+            $this->cache->set($key, $resource, $ttl ?: $this->ttl);
+        }
+
+        return $resource;
+    }
+
+    private function getKey(Show $action): string
+    {
+        return "jahuty_{$action->getResource()}_{$action->getId()}";
+    }
+}

--- a/src/Cache/Manager.php
+++ b/src/Cache/Manager.php
@@ -17,8 +17,7 @@ class Manager
 
     public function __construct(Client $client, Cache $cache, $ttl = null)
     {
-        if (
-            $ttl !== null &&
+        if ($ttl !== null &&
             $ttl !== (int)$ttl &&
             !($ttl instanceof \DateInterval)
         ) {
@@ -34,8 +33,7 @@ class Manager
 
     public function fetch(Action $action, $ttl = null): Resource
     {
-        if (
-            $ttl !== null &&
+        if ($ttl !== null &&
             $ttl !== (int)$ttl &&
             !($ttl instanceof \DateInterval)
         ) {

--- a/src/Cache/Memory.php
+++ b/src/Cache/Memory.php
@@ -88,7 +88,12 @@ class Memory implements CacheInterface
         return \array_key_exists($key, $this->values);
     }
 
-    public function set($key, $value, $ttl = null)
+    /**
+     * Keep in mind, ttl is required by the interface, but it's ignored here.
+     * The in-memory storage device (i.e., the array) doesn't survive the
+     * request cycle.
+     */
+    public function set($key, $value, $ttl = null)  // phpcs:ignore
     {
         if (!\is_string($key)) {
             throw new InvalidArgumentException(

--- a/src/Cache/Memory.php
+++ b/src/Cache/Memory.php
@@ -9,14 +9,14 @@ class Memory implements CacheInterface
 {
     private $values = [];
 
-    public function clear()
+    public function clear(): bool
     {
         $this->values = [];
 
         return true;
     }
 
-    public function delete($key)
+    public function delete($key): bool
     {
         if (!\is_string($key)) {
             throw new InvalidArgumentException(
@@ -31,7 +31,7 @@ class Memory implements CacheInterface
         return true;
     }
 
-    public function deleteMultiple($keys)
+    public function deleteMultiple($keys): bool
     {
         if (!\is_array($keys)) {
             throw new InvalidArgumentException(
@@ -61,7 +61,7 @@ class Memory implements CacheInterface
         return $this->values[(string)$key];
     }
 
-    public function getMultiple($keys, $default = null)
+    public function getMultiple($keys, $default = null): array
     {
         if (!\is_array($keys)) {
             throw new InvalidArgumentException(
@@ -78,7 +78,7 @@ class Memory implements CacheInterface
         return $values;
     }
 
-    public function has($key)
+    public function has($key): bool
     {
         if (!\is_string($key)) {
             throw new InvalidArgumentException(
@@ -88,7 +88,7 @@ class Memory implements CacheInterface
         return \array_key_exists($key, $this->values);
     }
 
-    public function set($key, $value, $ttl = null)
+    public function set($key, $value, $ttl = null): bool
     {
         if (!\is_string($key)) {
             throw new InvalidArgumentException(
@@ -117,7 +117,7 @@ class Memory implements CacheInterface
         return true;
     }
 
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple($values, $ttl = null): bool
     {
         if (!\is_array($values)) {
             throw new InvalidArgumentException(

--- a/src/Cache/Memory.php
+++ b/src/Cache/Memory.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Jahuty\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+use Jahuty\Exception\Cache as InvalidArgumentException;
+
+class Memory implements CacheInterface
+{
+    private $values = [];
+
+    public function clear()
+    {
+        $this->values = [];
+
+        return true;
+    }
+
+    public function delete($key)
+    {
+        if (!\is_string($key)) {
+            throw new InvalidArgumentException(
+                "Parameter one, key, is not a string"
+            );
+        }
+
+        if ($this->has($key)) {
+            unset($this->values[$key]);
+        }
+
+        return true;
+    }
+
+    public function deleteMultiple($keys)
+    {
+        if (!\is_array($keys)) {
+            throw new InvalidArgumentException(
+                "Parameter one, keys, must be an array"
+            );
+        }
+
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    public function get($key, $default = null)
+    {
+        if (!\is_string($key)) {
+            throw new InvalidArgumentException(
+                "Parameter one, key, must be a string"
+            );
+        }
+
+        if (!$this->has($key)) {
+            return $default;
+        }
+
+        return $this->values[(string)$key];
+    }
+
+    public function getMultiple($keys, $default = null)
+    {
+        if (!\is_array($keys)) {
+            throw new InvalidArgumentException(
+                "Parameter one, keys, must be an array"
+            );
+        }
+
+        $values = [];
+
+        foreach ($keys as $key) {
+            $values[$key] = $this->get($key, $default);
+        }
+
+        return $values;
+    }
+
+    public function has($key)
+    {
+        if (!\is_string($key)) {
+            throw new InvalidArgumentException(
+                "Parameter one, key, must be a string"
+            );
+        }
+        return \array_key_exists($key, $this->values);
+    }
+
+    public function set($key, $value, $ttl = null)
+    {
+        if (!\is_string($key)) {
+            throw new InvalidArgumentException(
+                "Parameter one, key, must be a string"
+            );
+        }
+
+        $this->values[$key] = $value;
+
+        return true;
+    }
+
+    public function setMultiple($values, $ttl = null)
+    {
+        if (!\is_array($values)) {
+            throw new InvalidArgumentException(
+                "Parameter one, values, must be an array"
+            );
+        }
+
+        foreach ($values as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+
+        return true;
+    }
+}

--- a/src/Client.php
+++ b/src/Client.php
@@ -43,7 +43,7 @@ class Client
         return $this->services->$name;
     }
 
-    public function fetch(Action\Action $action, $ttl = null): Resource\Resource
+    public function fetch(Action\Action $action, Ttl\Ttl $ttl): Resource\Resource
     {
         if (null === $this->cache) {
             $this->cache = new Cache\Manager(
@@ -106,14 +106,8 @@ class Client
             );
         }
 
-        if ($options['ttl'] !== null &&
-            (int)$options['ttl'] !== $options['ttl'] &&
-            !($options['ttl'] instanceof \DateInterval)
-        ) {
-            throw new \InvalidArgumentException(
-                "Option 'ttl' must be null, integer, or DateInterval"
-            );
-        }
+        // Accepts null, int, or DateInterval.
+        $options['ttl'] = new Ttl\Ttl($options['ttl']);
 
         $this->options = $options;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -98,8 +98,7 @@ class Client
     {
         $options = \array_merge($this->options, $options);
 
-        if (
-            $options['cache'] !== null &&
+        if ($options['cache'] !== null &&
             !($options['cache'] instanceof \Psr\SimpleCache\CacheInterface)
         ) {
             throw new \InvalidArgumentException(

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,11 +17,18 @@ class Client
 
     private $resources;
 
+    private $options = [
+        'cache' => null,
+        'ttl'   => 60
+    ];
+
     private $services;
 
-    public function __construct(string $key)
+    public function __construct(string $key, array $options = [])
     {
         $this->key = $key;
+
+        $this->setOptions($options);
     }
 
     public function __get(string $name): Service\Service
@@ -58,5 +65,30 @@ class Client
         }
 
         return $resource;
+    }
+
+    private function setOptions(array $options): void
+    {
+        $options = \array_merge($this->options, $options);
+
+        if (
+            $options['cache'] !== null &&
+            ! $options['cache'] instanceof CacheInterface
+        ) {
+            throw new \InvalidArgumentException(
+                "Option 'cache' must be null or CacheInterface"
+            );
+        }
+
+        if ($options['ttl'] !== null &&
+            (int)$options['ttl'] !== $options['ttl'] &&
+            ! $options['ttl'] instanceof \DateInterval
+        ) {
+            throw new \InvalidArgumentException(
+                "Option 'ttl' must be null, integer, or DateInterval"
+            );
+        }
+
+        $this->options = $options;
     }
 }

--- a/src/Exception/Cache.php
+++ b/src/Exception/Cache.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Jahuty\Exception;
+
+class Cache extends \Exception implements \Psr\SimpleCache\InvalidArgumentException
+{
+
+}

--- a/src/Jahuty.php
+++ b/src/Jahuty.php
@@ -6,5 +6,5 @@ class Jahuty
 {
     public const BASE_URI = 'https://api.jahuty.com';
 
-    public const VERSION = "5.0.0";
+    public const VERSION = "5.1.0";
 }

--- a/src/Service/Snippet.php
+++ b/src/Service/Snippet.php
@@ -4,6 +4,7 @@ namespace Jahuty\Service;
 
 use Jahuty\Action\Show;
 use Jahuty\Resource\Resource;
+use Jahuty\Ttl\Ttl;
 
 class Snippet extends Service
 {
@@ -18,11 +19,15 @@ class Snippet extends Service
 
         $params = [];
         if ($options['params']) {
-            $params['params'] = \json_encode($options['params'], JSON_THROW_ON_ERROR);
+            $params['params'] = \json_encode(
+                $options['params'],
+                JSON_THROW_ON_ERROR
+            );
         }
 
         $action = new Show('render', $id, $params);
+        $ttl    = new Ttl($options['ttl']);
 
-        return $this->client->fetch($action, $options['ttl']);
+        return $this->client->fetch($action, $ttl);
     }
 }

--- a/src/Service/Snippet.php
+++ b/src/Service/Snippet.php
@@ -9,14 +9,20 @@ class Snippet extends Service
 {
     public function render(int $id, array $options = []): Resource
     {
-        $params = [];
+        $defaults = [
+            'params' => null,
+            'ttl'    => null
+        ];
 
-        if (\array_key_exists('params', $options)) {
+        $options = \array_merge($defaults, $options);
+
+        $params = [];
+        if ($options['params']) {
             $params['params'] = \json_encode($options['params'], JSON_THROW_ON_ERROR);
         }
 
         $action = new Show('render', $id, $params);
 
-        return $this->client->request($action);
+        return $this->client->fetch($action, $options['ttl']);
     }
 }

--- a/src/Ttl/Ttl.php
+++ b/src/Ttl/Ttl.php
@@ -43,9 +43,7 @@ class Ttl
 
     public function toSeconds(): ?int
     {
-        if ($this->value === null) {
-            $seconds = null;
-        } elseif (is_int($this->value)) {
+        if ($this->value === null || is_int($this->value)) {
             $seconds = $this->value;
         } else {
             // The number of seconds in a DateInterval object depends on the

--- a/src/Ttl/Ttl.php
+++ b/src/Ttl/Ttl.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Jahuty\Ttl;
+
+/**
+ * The time between when an item is cached and when it is considered stale.
+ *
+ * According to PSR-16, there are several valid time-to-live values:
+ *
+ *   a null value
+ *     The implementing library may use a configured default duration, or
+ *     lacking that, store the item for as long as possible.
+ *
+ *   a positive integer value
+ *     The number of seconds to store the item.
+ *
+ *   a negative integer or zero value
+ *     The item must be deleted from the cache if it exists, as it is expired
+ *     already.
+ *
+ *   a DateInterval instance
+ *     The DateInterval to store the item.
+ */
+class Ttl
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        if ($value !== null && !is_int($value) && !($value instanceof \DateInterval)) {
+            throw new \InvalidArgumentException(
+                "Ttl must be null, int, or DateInterval"
+            );
+        }
+
+        $this->value = $value;
+    }
+
+    public function toSeconds(): ?int
+    {
+        if ($this->value === null) {
+            $seconds = null;
+        } elseif (is_int($this->value)) {
+            $seconds = $this->value;
+        } else {
+            // The number of seconds in a DateInterval object depends on the
+            // the current date and time.
+            //
+            // @see https://stackoverflow.com/a/25149337
+            $start   = new \DateTimeImmutable();
+            $end     = $start->add($this->value);
+            $seconds = $end->getTimestamp() - $start->getTimestamp();
+        }
+
+        return $seconds;
+    }
+}

--- a/src/Ttl/Ttl.php
+++ b/src/Ttl/Ttl.php
@@ -36,6 +36,11 @@ class Ttl
         $this->value = $value;
     }
 
+    public function isNull(): bool
+    {
+        return $this->value === null;
+    }
+
     public function toSeconds(): ?int
     {
         if ($this->value === null) {

--- a/tests/Cache/ManagerTest.php
+++ b/tests/Cache/ManagerTest.php
@@ -9,7 +9,7 @@ use Psr\SimpleCache\CacheInterface;
 
 class ManagerTest extends \PHPUnit\Framework\TestCase
 {
-    public function testConstructThrowsExceptionWhenTtlIsInvalid(): void
+    public function testConstructThrowsExceptionWhenDefaultTtlIsInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -20,7 +20,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testFetchThrowsExceptionIfTtlIsInvalid(): void
+    public function testFetchThrowsExceptionWhenArgumentTtlIsInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -40,11 +40,11 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         // stub a resource to return
         $resource = $this->createMock(Resource::class);
 
-        // stub cache to return the resource
+        // stub the cache to return the resource
         $cache = $this->createMock(CacheInterface::class);
         $cache->method('get')->willReturn($resource);
 
-        // instantiate manager with the stubbed cache
+        // instantiate the manager with the stubbed cache
         $manager = new Manager($this->createMock(Client::class), $cache);
 
         $this->assertSame(
@@ -75,55 +75,49 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testFetchReturnsResourceWhenDefaultTtlDoesNotExist(): void
+    public function testFetchReturnsResourceWhenTtlDoesNotExist(): void
     {
-        // stub a resource to return
+        // stub a resource for the cache to return
         $resource = $this->createMock(Resource::class);
 
-        // stub an action to fetch
+        // stub an action for the manager to fetch
         $action = $this->createMock(Show::class);
         $action->method('getResource')->willReturn('foo');
         $action->method('getId')->willReturn(1);
 
-        // define the expected cache key given the data above
-        $key = "jahuty_foo_1";
-
-        // stub the cache to miss and expect set
+        // stub the cache to miss and mock the cache to set the resource
         $cache = $this->createMock(CacheInterface::class);
         $cache->method('get')->willReturn(null);
 
         $cache->expects($this->once())
             ->method('set')
             ->with(
-                $this->identicalTo($key),
-                $this->identicalTo($resource),
-                $this->identicalTo(null)
+                $this->matchesRegularExpression('/[a-z0-9]/'),
+                $this->equalTo($resource),
+                $this->equalTo(null)
             );
 
-        // stub client to return the resource
+        // stub the jahuty client to return the resource
         $client = $this->createMock(Client::class);
         $client->method('request')->willReturn($resource);
 
-        // instantiate manager with the stubs
+        // instantiate the manager with the stubs
         $manager = new Manager($client, $cache);
 
         $this->assertSame($resource, $manager->fetch($action));
     }
 
-    public function testFetchReturnsResourceWhenDefaultTtlDoesExist(): void
+    public function testFetchReturnsResourceWhenGlobalTtlDoesExist(): void
     {
         $defaultTtl = 60;
 
-        // stub a resource to return
+        // stub a resource for the cache to return
         $resource = $this->createMock(Resource::class);
 
-        // stub an action to fetch
+        // stub an action for the manager to fetch
         $action = $this->createMock(Show::class);
         $action->method('getResource')->willReturn('foo');
         $action->method('getId')->willReturn(1);
-
-        // define the expected cache key given the data above
-        $key = "jahuty_foo_1";
 
         // stub the cache to miss and expect set
         $cache = $this->createMock(CacheInterface::class);
@@ -132,16 +126,16 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         $cache->expects($this->once())
             ->method('set')
             ->with(
-                $this->identicalTo($key),
-                $this->identicalTo($resource),
-                $this->identicalTo($defaultTtl)
+                $this->matchesRegularExpression('/[a-z0-9]/'),
+                $this->equalTo($resource),
+                $this->equalTo($defaultTtl)
             );
 
-        // stub client to return the resource
+        // stub the jahuty client to return the resource
         $client = $this->createMock(Client::class);
         $client->method('request')->willReturn($resource);
 
-        // instantiate manager with the stubs
+        // instantiate manager with the stubs and default ttl
         $manager = new Manager($client, $cache, $defaultTtl);
 
         $this->assertSame($resource, $manager->fetch($action));
@@ -152,27 +146,24 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         $globalTtl = 10;
         $localTtl  = 100;
 
-        // stub a resource to return
+        // stub a resource for the cache to return
         $resource = $this->createMock(Resource::class);
 
-        // stub an action to fetch
+        // stub an action for the manager to fetch
         $action = $this->createMock(Show::class);
         $action->method('getResource')->willReturn('foo');
         $action->method('getId')->willReturn(1);
 
-        // define the expected cache key given the data above
-        $key = "jahuty_foo_1";
-
-        // stub the cache to miss and expect set
+        // stub the cache to miss and expect a set
         $cache = $this->createMock(CacheInterface::class);
         $cache->method('get')->willReturn(null);
 
         $cache->expects($this->once())
             ->method('set')
             ->with(
-                $this->identicalTo($key),
-                $this->identicalTo($resource),
-                $this->identicalTo($localTtl)
+                $this->matchesRegularExpression('/[a-z0-9]/'),
+                $this->equalTo($resource),
+                $this->equalTo($localTtl)
             );
 
         // stub client to return the resource

--- a/tests/Cache/ManagerTest.php
+++ b/tests/Cache/ManagerTest.php
@@ -5,36 +5,11 @@ namespace Jahuty\Cache;
 use Jahuty\Action\{Action, Show};
 use Jahuty\Client;
 use Jahuty\Resource\Resource;
+use Jahuty\Ttl\Ttl;
 use Psr\SimpleCache\CacheInterface;
 
 class ManagerTest extends \PHPUnit\Framework\TestCase
 {
-    public function testConstructThrowsExceptionWhenDefaultTtlIsInvalid(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        new Manager(
-            $this->createMock(Client::class),
-            $this->createMock(CacheInterface::class),
-            'foo'  // must be null, int, or DateInterval
-        );
-    }
-
-    public function testFetchThrowsExceptionWhenArgumentTtlIsInvalid(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        $manager = new Manager(
-            $this->createMock(Client::class),
-            $this->createMock(CacheInterface::class),
-            60
-        );
-
-        $action = $this->createMock(Action::class);
-
-        $manager->fetch($action, 'foo');
-    }
-
     public function testFetchReturnsResourceWhenResourceIsCached(): void
     {
         // stub a resource to return
@@ -45,11 +20,18 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         $cache->method('get')->willReturn($resource);
 
         // instantiate the manager with the stubbed cache
-        $manager = new Manager($this->createMock(Client::class), $cache);
+        $manager = new Manager(
+            $this->createMock(Client::class),
+            $cache,
+            $this->createMock(Ttl::class)
+        );
 
         $this->assertSame(
             $resource,
-            $manager->fetch($this->createMock(Show::class))
+            $manager->fetch(
+                $this->createMock(Show::class),
+                $this->createMock(Ttl::class)
+            )
         );
     }
 
@@ -67,11 +49,14 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         $client->method('request')->willReturn($resource);
 
         // instantiate manager with the stubs
-        $manager = new Manager($client, $cache);
+        $manager = new Manager($client, $cache, $this->createMock(Ttl::class));
 
         $this->assertSame(
             $resource,
-            $manager->fetch($this->createMock(Show::class))
+            $manager->fetch(
+                $this->createMock(Show::class),
+                $this->createMock(Ttl::class)
+            )
         );
     }
 
@@ -102,14 +87,18 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         $client->method('request')->willReturn($resource);
 
         // instantiate the manager with the stubs
-        $manager = new Manager($client, $cache);
+        $manager = new Manager($client, $cache, $this->createMock(Ttl::class));
 
-        $this->assertSame($resource, $manager->fetch($action));
+        $this->assertSame(
+            $resource,
+            $manager->fetch($action, $this->createMock(Ttl::class))
+        );
     }
 
     public function testFetchReturnsResourceWhenGlobalTtlDoesExist(): void
     {
-        $defaultTtl = 60;
+        $globalTtl = new Ttl(60);
+        $localTtl  = new Ttl(null);
 
         // stub a resource for the cache to return
         $resource = $this->createMock(Resource::class);
@@ -128,7 +117,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
             ->with(
                 $this->matchesRegularExpression('/[a-z0-9]/'),
                 $this->equalTo($resource),
-                $this->equalTo($defaultTtl)
+                $this->equalTo($globalTtl->toSeconds())
             );
 
         // stub the jahuty client to return the resource
@@ -136,15 +125,18 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
         $client->method('request')->willReturn($resource);
 
         // instantiate manager with the stubs and default ttl
-        $manager = new Manager($client, $cache, $defaultTtl);
+        $manager = new Manager($client, $cache, $globalTtl);
 
-        $this->assertSame($resource, $manager->fetch($action));
+        $this->assertSame(
+            $resource,
+            $manager->fetch($action, $localTtl)
+        );
     }
 
     public function testFetchReturnsResourceWhenLocalTtlDoesExist(): void
     {
-        $globalTtl = 10;
-        $localTtl  = 100;
+        $globalTtl = new Ttl(10);
+        $localTtl  = new Ttl(100);
 
         // stub a resource for the cache to return
         $resource = $this->createMock(Resource::class);
@@ -163,7 +155,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
             ->with(
                 $this->matchesRegularExpression('/[a-z0-9]/'),
                 $this->equalTo($resource),
-                $this->equalTo($localTtl)
+                $this->equalTo($localTtl->toSeconds())
             );
 
         // stub client to return the resource

--- a/tests/Cache/ManagerTest.php
+++ b/tests/Cache/ManagerTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Jahuty\Cache;
+
+use Jahuty\Action\{Action, Show};
+use Jahuty\Client;
+use Jahuty\Resource\Resource;
+use Psr\SimpleCache\CacheInterface;
+
+class ManagerTest extends \PHPUnit\Framework\TestCase
+{
+    public function testConstructThrowsExceptionWhenTtlIsInvalid(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Manager(
+            $this->createMock(Client::class),
+            $this->createMock(CacheInterface::class),
+            'foo'  // must be null, int, or DateInterval
+        );
+    }
+
+    public function testFetchThrowsExceptionIfTtlIsInvalid(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $manager = new Manager(
+            $this->createMock(Client::class),
+            $this->createMock(CacheInterface::class),
+            60
+        );
+
+        $action = $this->createMock(Action::class);
+
+        $manager->fetch($action, 'foo');
+    }
+
+    public function testFetchReturnsResourceWhenResourceIsCached(): void
+    {
+        // stub a resource to return
+        $resource = $this->createMock(Resource::class);
+
+        // stub cache to return the resource
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')->willReturn($resource);
+
+        // instantiate manager with the stubbed cache
+        $manager = new Manager($this->createMock(Client::class), $cache);
+
+        $this->assertSame(
+            $resource,
+            $manager->fetch($this->createMock(Show::class))
+        );
+    }
+
+    public function testFetchReturnsResourceWhenResourceIsNotCached(): void
+    {
+        // stub a resource to return
+        $resource = $this->createMock(Resource::class);
+
+        // stub cache to miss
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')->willReturn(null);
+
+        // stub client to return the resource
+        $client = $this->createMock(Client::class);
+        $client->method('request')->willReturn($resource);
+
+        // instantiate manager with the stubs
+        $manager = new Manager($client, $cache);
+
+        $this->assertSame(
+            $resource,
+            $manager->fetch($this->createMock(Show::class))
+        );
+    }
+
+    public function testFetchReturnsResourceWhenDefaultTtlDoesNotExist(): void
+    {
+        // stub a resource to return
+        $resource = $this->createMock(Resource::class);
+
+        // stub an action to fetch
+        $action = $this->createMock(Show::class);
+        $action->method('getResource')->willReturn('foo');
+        $action->method('getId')->willReturn(1);
+
+        // define the expected cache key given the data above
+        $key = "jahuty_foo_1";
+
+        // stub the cache to miss and expect set
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')->willReturn(null);
+
+        $cache->expects($this->once())
+            ->method('set')
+            ->with(
+                $this->identicalTo($key),
+                $this->identicalTo($resource),
+                $this->identicalTo(null)
+            );
+
+        // stub client to return the resource
+        $client = $this->createMock(Client::class);
+        $client->method('request')->willReturn($resource);
+
+        // instantiate manager with the stubs
+        $manager = new Manager($client, $cache);
+
+        $this->assertSame($resource, $manager->fetch($action));
+    }
+
+    public function testFetchReturnsResourceWhenDefaultTtlDoesExist(): void
+    {
+        $defaultTtl = 60;
+
+        // stub a resource to return
+        $resource = $this->createMock(Resource::class);
+
+        // stub an action to fetch
+        $action = $this->createMock(Show::class);
+        $action->method('getResource')->willReturn('foo');
+        $action->method('getId')->willReturn(1);
+
+        // define the expected cache key given the data above
+        $key = "jahuty_foo_1";
+
+        // stub the cache to miss and expect set
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')->willReturn(null);
+
+        $cache->expects($this->once())
+            ->method('set')
+            ->with(
+                $this->identicalTo($key),
+                $this->identicalTo($resource),
+                $this->identicalTo($defaultTtl)
+            );
+
+        // stub client to return the resource
+        $client = $this->createMock(Client::class);
+        $client->method('request')->willReturn($resource);
+
+        // instantiate manager with the stubs
+        $manager = new Manager($client, $cache, $defaultTtl);
+
+        $this->assertSame($resource, $manager->fetch($action));
+    }
+
+    public function testFetchReturnsResourceWhenLocalTtlDoesExist(): void
+    {
+        $globalTtl = 10;
+        $localTtl  = 100;
+
+        // stub a resource to return
+        $resource = $this->createMock(Resource::class);
+
+        // stub an action to fetch
+        $action = $this->createMock(Show::class);
+        $action->method('getResource')->willReturn('foo');
+        $action->method('getId')->willReturn(1);
+
+        // define the expected cache key given the data above
+        $key = "jahuty_foo_1";
+
+        // stub the cache to miss and expect set
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')->willReturn(null);
+
+        $cache->expects($this->once())
+            ->method('set')
+            ->with(
+                $this->identicalTo($key),
+                $this->identicalTo($resource),
+                $this->identicalTo($localTtl)
+            );
+
+        // stub client to return the resource
+        $client = $this->createMock(Client::class);
+        $client->method('request')->willReturn($resource);
+
+        // instantiate manager with the stubs
+        $manager = new Manager($client, $cache, $globalTtl);
+
+        $this->assertSame($resource, $manager->fetch($action, $localTtl));
+    }
+}

--- a/tests/Cache/ManagerTest.php
+++ b/tests/Cache/ManagerTest.php
@@ -2,7 +2,7 @@
 
 namespace Jahuty\Cache;
 
-use Jahuty\Action\{Action, Show};
+use Jahuty\Action\Show;
 use Jahuty\Client;
 use Jahuty\Resource\Resource;
 use Jahuty\Ttl\Ttl;

--- a/tests/Cache/MemoryTest.php
+++ b/tests/Cache/MemoryTest.php
@@ -1,0 +1,176 @@
+<?php
+namespace Jahuty\Cache;
+
+use Psr\SimpleCache\InvalidArgumentException;
+
+class MemoryTest extends \PHPUnit\Framework\TestCase
+{
+    public function testClearReturnsTrue(): void
+    {
+        $key   = 'foo';
+        $cache = new Memory();
+
+        $cache->set($key, 1);
+
+        $this->assertTrue($cache->has($key));
+
+        $this->assertTrue($cache->clear());
+
+        $this->assertFalse($cache->has($key));
+    }
+
+    public function testDeleteThrowsExceptionWhenKeyIsNotString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Memory())->delete(1);
+    }
+
+    public function testDeleteReturnsTrueWhenKeyIsString(): void
+    {
+        $key   = 'foo';
+        $cache = new Memory();
+
+        $cache->set($key, 1);
+
+        $this->assertTrue($cache->has($key));
+
+        $this->assertTrue($cache->delete($key));
+
+        $this->assertFalse($cache->has($key));
+    }
+
+    public function testDeleteMultipleThrowsExceptionWhenKeysIsNotvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Memory())->deleteMultiple('foo');
+    }
+
+    public function testDeleteMultipleReturnsTrueWhenKeysIsValid(): void
+    {
+        $key   = 'foo';
+        $keys  = [$key];
+        $cache = new Memory();
+
+        $cache->set($key, 1);
+
+        $this->assertTrue($cache->has($key));
+
+        $this->assertTrue($cache->deleteMultiple($keys));
+
+        $this->assertFalse($cache->has($key));
+    }
+
+    public function testGetThrowsExceptionWhenKeyIsNotValid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Memory())->get(1);
+    }
+
+    public function testGetReturnsDefaultIfValueDoesNotExist(): void
+    {
+        $this->assertEquals('bar', (new Memory())->get('foo', 'bar'));
+    }
+
+    public function testGetReturnsValueIfValueDoesExist(): void
+    {
+        $key   = 'foo';
+        $value = 1;
+        $cache = new Memory();
+
+        $cache->set($key, $value);
+
+        $this->assertEquals($value, $cache->get($key));
+    }
+
+    public function testGetMultipleThrowsExceptionWhenKeysIsInvalid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Memory())->getMultiple(1);
+    }
+
+    public function testGetMultipleReturnsDefaultWhenValuesNotCached(): void
+    {
+        $keys    = ['foo', 'bar'];
+        $cache   = new Memory();
+        $default = 'baz';
+
+        $expected = ['foo' => 'baz', 'bar' => 'baz'];
+        $actual   = $cache->getMultiple($keys, $default);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetMultiple(): void
+    {
+        $cache = new Memory();
+
+        $cache->set('foo', 1);
+        $cache->set('bar', 1);
+
+        $expected = ['foo' => 1, 'bar' => 1];
+        $actual   = $cache->getMultiple(['foo', 'bar']);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testHasThrowsExceptionIfKeyIsNotValid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Memory())->has(1);
+    }
+
+    public function testHasReturnsTrueWhenKeyDoesExist(): void
+    {
+        $cache = new Memory();
+
+        $cache->set('foo', 1);
+
+        $this->assertTrue($cache->has('foo'));
+    }
+
+    public function testHasReturnsFalseWhenKeyDoesNotExist(): void
+    {
+        $this->assertFalse((new Memory())->has('foo'));
+    }
+
+    public function testSetThrowsExceptionIfKeyNotValid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Memory())->set(1, 'foo');
+    }
+
+    public function testSet(): void
+    {
+        $cache = new Memory();
+
+        $this->assertFalse($cache->has('foo'));
+
+        $this->assertTrue($cache->set('foo', true));
+
+        $this->assertTrue($cache->has('foo'));
+    }
+
+    public function testSetMultipleThrowsExceptionIfValuesIsNotValid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new Memory())->setMultiple(1);
+    }
+
+    public function testSetMultiple(): void
+    {
+        $cache = new Memory();
+
+        $this->assertFalse($cache->has('foo'));
+
+        $this->assertTrue($cache->setMultiple(['foo' => true]));
+
+        $this->assertTrue($cache->has('foo'));
+    }
+}

--- a/tests/Cache/MemoryTest.php
+++ b/tests/Cache/MemoryTest.php
@@ -145,7 +145,15 @@ class MemoryTest extends \PHPUnit\Framework\TestCase
         (new Memory())->set(1, 'foo');
     }
 
-    public function testSet(): void
+    public function testSetThrowsExeptionIfTtlNotValid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        // ttl must be null, int, or DateInterval
+        (new Memory())->set(1, 'foo', 'foo');
+    }
+
+    public function testSetIfTtlIsNull(): void
     {
         $cache = new Memory();
 
@@ -154,6 +162,39 @@ class MemoryTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($cache->set('foo', true));
 
         $this->assertTrue($cache->has('foo'));
+    }
+
+    public function testSetIfTtlIsPositiveInteger(): void
+    {
+        $cache = new Memory();
+
+        $this->assertFalse($cache->has('foo'));
+
+        $this->assertTrue($cache->set('foo', true, 1));
+
+        $this->assertTrue($cache->has('foo'));
+    }
+
+    public function testSetIfTtlIsZero(): void
+    {
+        $cache = new Memory();
+
+        $this->assertFalse($cache->has('foo'));
+
+        $this->assertTrue($cache->set('foo', true, 0));
+
+        $this->assertFalse($cache->has('foo'));
+    }
+
+    public function testSetIfTtlIsNegativeInteger(): void
+    {
+        $cache = new Memory();
+
+        $this->assertFalse($cache->has('foo'));
+
+        $this->assertTrue($cache->set('foo', true, -1));
+
+        $this->assertFalse($cache->has('foo'));
     }
 
     public function testSetMultipleThrowsExceptionIfValuesIsNotValid(): void

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,6 +4,20 @@ namespace Jahuty;
 
 class ClientTest extends \PHPUnit\Framework\TestCase
 {
+    public function testConstructThrowsExceptionWhenCacheInvalid(): void
+    {
+        $this->expectException(\InvalidARgumentException::class);
+
+        (new Client('foo', ['cache' => 'foo']));
+    }
+
+    public function testConstructThrowsExceptionWhenTtlInvalid(): void
+    {
+        $this->expectException(\InvalidARgumentException::class);
+
+        (new Client('foo', ['ttl' => 'foo']));
+    }
+
     public function testMagicGetThrowsExceptionWhenServiceDoesNotExist(): void
     {
         $this->expectException(\OutOfBoundsException::class);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -32,19 +32,4 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             (new Client('foo'))->snippets
         );
     }
-
-    /**
-     * An end-to-end test using a live key and snippet.
-     */
-    public function testRequest(): void
-    {
-        $jahuty = new Client('kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc');
-
-        $render = $jahuty->snippets->render(1);
-
-        $this->assertEquals(
-            '<p>This is my first snippet!</p>',
-            $render->getContent()
-        );
-    }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,8 +2,26 @@
 
 namespace Jahuty;
 
+use donatj\MockWebServer\{MockWebServer, Response};
+use Jahuty\Action\Show;
+use Jahuty\Resource\Render;
+use Psr\SimpleCache\CacheInterface;
+
 class ClientTest extends \PHPUnit\Framework\TestCase
 {
+    private static $server;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$server = new MockWebServer();
+        self::$server->start();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$server->stop();
+    }
+
     public function testConstructThrowsExceptionWhenCacheInvalid(): void
     {
         $this->expectException(\InvalidARgumentException::class);
@@ -15,6 +33,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\InvalidARgumentException::class);
 
+        // TTL must be null, int, or DateInterval.
         (new Client('foo', ['ttl' => 'foo']));
     }
 
@@ -31,5 +50,101 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             Service\Snippet::class,
             (new Client('foo'))->snippets
         );
+    }
+
+    public function testFetchReturnsResourceWhenSuccess(): void
+    {
+        $id      = 1;
+        $content = 'foo';
+
+        $this->setupEndpointWithSuccess($id, $content);
+
+        // Mock the cache to store the returned value.
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->once())->method('set');
+
+        $client = new Client('1234abcd', [
+            'base_uri' => self::$server->getServerRoot(),
+            'cache'    => $cache
+        ]);
+
+        $action = new Show('render', $id);
+
+        $expected = new Render($content);
+        $actual   = $client->fetch($action);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testFetchThrowsExceptionWhenProblem(): void
+    {
+        $id = 1;
+
+        $this->expectException(Exception\Error::class);
+
+        $this->setupEndpointWithProblem($id);
+
+        // Mock the cache NOT TO store the returned problem.
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->never())->method('set');
+
+        $client = new Client('1234abcd', [
+            'base_uri' => self::$server->getServerRoot(),
+            'cache'    => $cache
+        ]);
+
+        $client->fetch(new Show('render', $id));
+    }
+
+    public function testRequestThrowsExceptionWhenProblem(): void
+    {
+        $id = 1;
+
+        $this->expectException(Exception\Error::class);
+
+        $this->setupEndpointWithProblem($id);
+
+        $client = new Client('1234abcd', [
+            'base_uri' => self::$server->getServerRoot()
+        ]);
+
+        $client->request(new Show('render', $id));
+    }
+
+    public function testRequestReturnsResourceWhenSuccess(): void
+    {
+        $id      = 1;
+        $content = 'foo';
+
+        $this->setupEndpointWithSuccess($id, $content);
+
+        $client = new Client('1234abcd', [
+            'base_uri' => self::$server->getServerRoot()
+        ]);
+
+        $action = new Show('render', $id);
+
+        $expected = new Render($content);
+        $actual   = $client->request($action);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    private function setupEndpointWithSuccess($id = 1, $content = 'foo'): void
+    {
+        $response = new Response('{"content":"'. $content .'"}', [], 200);
+
+        self::$server->setResponseOfPath("snippets/$id/render", $response);
+    }
+
+    private function setupEndpointWithProblem($id = 1): void
+    {
+        $response = new Response(
+            '{"status":404,"type":"foo","detail":"bar"}',
+            ['Content-Type' => 'application/problem+json'],
+            404
+        );
+
+        self::$server->setResponseOfPath("snippets/$id/render", $response);
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -5,6 +5,7 @@ namespace Jahuty;
 use donatj\MockWebServer\{MockWebServer, Response};
 use Jahuty\Action\Show;
 use Jahuty\Resource\Render;
+use Jahuty\Ttl\Ttl;
 use Psr\SimpleCache\CacheInterface;
 
 class ClientTest extends \PHPUnit\Framework\TestCase
@@ -71,7 +72,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $action = new Show('render', $id);
 
         $expected = new Render($content);
-        $actual   = $client->fetch($action);
+        $actual   = $client->fetch($action, $this->createMock(Ttl::class));
 
         $this->assertEquals($expected, $actual);
     }
@@ -93,7 +94,10 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             'cache'    => $cache
         ]);
 
-        $client->fetch(new Show('render', $id));
+        $client->fetch(
+            new Show('render', $id),
+            $this->createMock(Ttl::class)
+        );
     }
 
     public function testRequestThrowsExceptionWhenProblem(): void

--- a/tests/Resource/RenderTest.php
+++ b/tests/Resource/RenderTest.php
@@ -37,4 +37,12 @@ class RenderTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals('foo', (string)new Render('foo'));
     }
+
+    // Required for caching.
+    public function testObjectSpportsLosslessSerializationAndDeserialization(): void
+    {
+        $render = new Render('foo');
+
+        $this->assertEquals($render, unserialize(serialize($render)));
+    }
 }

--- a/tests/Service/SnippetTest.php
+++ b/tests/Service/SnippetTest.php
@@ -13,8 +13,8 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
 
         $client = $this->createMock(Client::class);
         $client->expects($this->once())
-            ->method('request')
-            ->with($this->equalTo($action));
+            ->method('fetch')
+            ->with($this->equalTo($action), $this->equalTo(null));
 
         (new Snippet($client))->render(1);
     }
@@ -25,9 +25,24 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
 
         $client = $this->createMock(Client::class);
         $client->expects($this->once())
-            ->method('request')
-            ->with($this->equalTo($action));
+            ->method('fetch')
+            ->with($this->equalTo($action), $this->equalTo(null));
 
         (new Snippet($client))->render(1, ['params' => ['foo' => 'bar']]);
+    }
+
+    public function testRenderWhenParamsAndTllDoExist(): void
+    {
+        $action = new Show('render', 1, ['params' => '{"foo":"bar"}']);
+
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('fetch')
+            ->with($this->equalTo($action), $this->equalTo(60));
+
+        (new Snippet($client))->render(1, [
+            'params' => ['foo' => 'bar'],
+            'ttl'    => 60
+        ]);
     }
 }

--- a/tests/Service/SnippetTest.php
+++ b/tests/Service/SnippetTest.php
@@ -4,6 +4,7 @@ namespace Jahuty\Service;
 
 use Jahuty\Client;
 use Jahuty\Action\Show;
+use Jahuty\Ttl\Ttl;
 
 class SnippetTest extends \PHPUnit\Framework\TestCase
 {
@@ -14,7 +15,7 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
         $client = $this->createMock(Client::class);
         $client->expects($this->once())
             ->method('fetch')
-            ->with($this->equalTo($action), $this->equalTo(null));
+            ->with($this->equalTo($action), $this->isInstanceOf(Ttl::class));
 
         (new Snippet($client))->render(1);
     }
@@ -26,7 +27,7 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
         $client = $this->createMock(Client::class);
         $client->expects($this->once())
             ->method('fetch')
-            ->with($this->equalTo($action), $this->equalTo(null));
+            ->with($this->equalTo($action), $this->isInstanceOf(Ttl::class));
 
         (new Snippet($client))->render(1, ['params' => ['foo' => 'bar']]);
     }
@@ -38,7 +39,7 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
         $client = $this->createMock(Client::class);
         $client->expects($this->once())
             ->method('fetch')
-            ->with($this->equalTo($action), $this->equalTo(60));
+            ->with($this->equalTo($action), $this->equalTo(new Ttl(60)));
 
         (new Snippet($client))->render(1, [
             'params' => ['foo' => 'bar'],

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -4,7 +4,7 @@ namespace Jahuty;
 
 class SystemTest extends \PHPUnit\Framework\TestCase
 {
-    public function testRequest(): void
+    public function testRender(): void
     {
         $jahuty = new Client('kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc');
 
@@ -14,5 +14,24 @@ class SystemTest extends \PHPUnit\Framework\TestCase
             '<p>This is my first snippet!</p>',
             $render->getContent()
         );
+    }
+
+    public function testRenderCaching(): void
+    {
+        $jahuty = new Client('kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc');
+
+        // The first call requests the snippet and warms the cache.
+        $render = $jahuty->snippets->render(1);
+
+        // The second request hits the cache.
+        $start  = microtime(true);
+        $render = $jahuty->snippets->render(1);
+        $end    = microtime(true);
+
+        // The actual time should less than a maximum number of milliseconds.
+        $maximum = 1;
+        $actual  = ($end - $start) * 1000;
+
+        $this->assertLessThan($maximum, $actual);
     }
 }

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Jahuty;
+
+class SystemTest extends \PHPUnit\Framework\TestCase
+{
+    public function testRequest(): void
+    {
+        $jahuty = new Client('kn2Kj5ijmT2pH6ZKqAQyNexUqKeRM4VG6DDgWN1lIcc');
+
+        $render = $jahuty->snippets->render(1);
+
+        $this->assertEquals(
+            '<p>This is my first snippet!</p>',
+            $render->getContent()
+        );
+    }
+}

--- a/tests/Ttl/TtlTest.php
+++ b/tests/Ttl/TtlTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Jahuty\Ttl;
+
+class TtlTest extends \PHPUnit\Framework\TestCase
+{
+    public function testConstructWhenValueIsInvalid(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Ttl('foo');
+    }
+
+    public function testConstructWhenValueIsNull(): void
+    {
+        $this->assertInstanceOf(Ttl::class, new Ttl(null));
+    }
+
+    public function testConstructWhenValueIsInt(): void
+    {
+        $this->assertInstanceOf(Ttl::class, new Ttl(1));
+    }
+
+    public function testConstructWhenValueIsDateInterval(): void
+    {
+        $this->assertInstanceOf(Ttl::class, new Ttl(new \DateInterval('PT1S')));
+    }
+
+    public function testToSecondsWhenValueIsNull(): void
+    {
+        $this->assertNull((new Ttl(null))->toSeconds());
+    }
+
+    public function testToSecondsWhenValueIsPositiveInt(): void
+    {
+        $this->assertEquals(1, (new Ttl(1))->toSeconds());
+    }
+
+    public function testToSecondsWhenValueIsZero(): void
+    {
+        $this->assertEquals(0, (new Ttl(0))->toSeconds());
+    }
+
+    public function testToSecondsWhenValueIsNegativeInt(): void
+    {
+        $this->assertEquals(-1, (new Ttl(-1))->toSeconds());
+    }
+
+    public function testToSecondsWhenValueIsDateInterval(): void
+    {
+        $this->assertEquals(1, (new Ttl(new \DateInterval('PT1S')))->toSeconds());
+    }
+}

--- a/tests/Ttl/TtlTest.php
+++ b/tests/Ttl/TtlTest.php
@@ -26,6 +26,16 @@ class TtlTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(Ttl::class, new Ttl(new \DateInterval('PT1S')));
     }
 
+    public function testIsNullReturnsTrueWhenNull(): void
+    {
+        $this->assertTrue((new Ttl(null))->isNull());
+    }
+
+    public function testIsNullReturnsFalseWhenNotNull(): void
+    {
+        $this->assertFalse((new Ttl(1))->isNull());
+    }
+
     public function testToSecondsWhenValueIsNull(): void
     {
         $this->assertNull((new Ttl(null))->toSeconds());


### PR DESCRIPTION
Add caching! 

1. Allow users to pass a [PSR-16](https://www.php-fig.org/psr/psr-16/) cache into `Jahuty\Client`. 
2. Allow users to configure the cache's time-to-live at the SDK- or snippet-level.
3. Implement an "in memory" PSR-16 cache adapter. There are many popular caching libraries available, however, building our own lightweight adapter seemed more economical than adding a large dependency like [Symfony/Cache](https://symfony.com/doc/current/components/cache.html) when we only want an array adapter. 
3. Default to use the "in memory" array-based cache if no cache is provided. This will increase performance in the use case when the same snippet is rendered multiple times. 

I also moved system tests to a separate file and improved the tests for `Jahuty\Client`.

Closes #12 