### PR TITLE
Move ttl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.1.1 - 2020-12-27
+
+- Move `Jahuty\Ttl\Ttl` to `Jahuty\Cache\Ttl`.
+- Change the caching section introduction and examples in the `README` to improve explanations.
+
 ## 5.1.0 - 2020-12-26
 
 - Add a second, optional parameter to `Jahuty\Client`, an options array with support for the following options: `cache`, a `CacheInterface` implementation); `ttl`, a `null`, `int`, or `DateInterval` SDK-wide time-to-live; and, `base_uri`, the base URI for API requests (useful for testing).

--- a/README.md
+++ b/README.md
@@ -22,19 +22,23 @@ It should be installed via [Composer](https://getcomposer.org). To do so, add th
 
 ## Usage
 
-Instantiate the library with your [API key](https://docs.jahuty.com/api#authentication), and use the `render()` method to output your snippet:
+Instantiate the library with your [API key](https://docs.jahuty.com/api#authentication) and use the `snippets->render()` method to render your snippet:
 
 ```php
 $jahuty = new \Jahuty\Client('YOUR_API_KEY');
 
-// render the snippet...
+$render = $jahuty->snippets->render(YOUR_SNIPPET_ID);
+```
+
+Then, output the render's content by casting it to a `string` or using its `getContent()` method:
+
+```php
+$jahuty = new \Jahuty\Client('YOUR_API_KEY');
+
 $render = $jahuty->snippets->render(YOUR_SNIPPET_ID);
 
-// .. and, cast it to a string...
-(string)$render;
-
-// ...or, access its content
-$render->getContent();
+echo $render;
+echo $render->getContent();
 ```
 
 In an HTML view:
@@ -75,17 +79,20 @@ The parameters above would be equivalent to [assigning the variables](https://do
 
 ## Caching
 
-Caching allows you to tune your application's response time based on your content's stability and traffic. By caching a render for a period of time, you can decrease the number of synchronous requests to Jahuty's API, and thereby increase your response time.
+Caching controls how frequently this library requests content from Jahuty's API.
+
+* In _development_, where content is frequently changing and low traffic, you can use the default in-memory store to view content changes instantaneously.
+* In _production_, where content is more stable and high traffic, you can configure persistent caching to reduce network requests and improve your application's response time.
 
 ### Caching in memory (default)
 
-By default, Jahuty uses an in-memory cache to avoid requesting the same render more than once during the same request's lifecycle. For example:
+By default, Jahuty uses an in-memory cache to avoid requesting the same render more than once during the same request lifecycle. For example:
 
 ```php
 $jahuty = new \Jahuty\Client('YOUR_API_KEY');
 
 // This call sends a synchronous API request; caches the result in memory; and,
-// returns it to the caller.
+// returns the result to the caller.
 $render1 = $jahuty->snippets->render(YOUR_SNIPPET_ID);
 
 // This call skips sending an API request and uses the cached value instead.
@@ -96,44 +103,55 @@ The in-memory cache only persists for the duration of the original request, howe
 
 ### Caching persistently
 
-A persistent cache allows renders to be cached across multiple requests. This reduces the number of synchronous network requests to Jahuty's API and your application's average response time.
+A persistent cache allows renders to be cached across multiple requests. This reduces the number of synchronous network requests to Jahuty's API and improves your application's average response time.
 
-To configure Jahuty to use your persistent cache, pass a [PSR-16](https://www.php-fig.org/psr/psr-16/) `CacheInterface` implementation to the client via the `cache` configuration option:
+To configure Jahuty to use your persistent cache, pass a [PSR-16 `CacheInterface`](https://www.php-fig.org/psr/psr-16/) implementation to the client via the `cache` configuration option:
 
 ```php
 $jahuty = new \Jahuty\Client('YOUR_API_KEY', ['cache' => $cache]);
 ```
+
+The persistent cache implementation you choose and configure is up to you. There are many libraries available, and most frameworks provide their own. Any PSR-16 compatible implementation will work.
 
 ### Expiring
 
-There are three methods for configuring a render's Time to Live (TTL). From lowest-to-highest precedence, they are as follows: configuring your caching implementation, configuring this library's default TTL, and configuring a render's TTL.
+There are three methods for configuring a render's Time to Live (TTL), the amount of time between when a render is stored and when it's considered stale. From lowest-to-highest precedence, they are:
+
+1. configuring your caching implementation,
+1. configuring this library's default TTL, and
+1. configuring a render's TTL.
 
 #### Configuring your caching implementation
 
-Many cache implementations allow you to set a default TTL, which this library will use by default.
+You can usually configure your caching implementation with a default TTL. If no other TTL is configured, this library will defer to the caching implementation's default TTL.
 
 #### Configuring this library's default TTL
 
-Or, you can pass an integer number of seconds or a `DateInterval` instance via the client's `ttl` configuration option, which will be used for all renders:
+You can configure a default TTL for all of this library's renders by passing an integer number of seconds or a `DateInterval` instance via the client's `ttl` configuration option:
 
 ```php
-// cache all renders for sixty seconds
 $jahuty = new \Jahuty\Client('YOUR_API_KEY', [
   'cache' => $cache,
-  'ttl'   => 60
+  'ttl'   => 60  // <- cache all renders for sixty seconds
 ]);
 ```
 
+If this library's default TTL is set, it will take precedence over the default TTL of the caching implementation.
+
 #### Configuring a render's TTL
 
-Finally, you can pass an integer number of seconds or a `DateInterval` instance via a render's `ttl` configuration option to fine-tune a render's time to live:
+You can configure one render's TTL by passing an integer number of seconds or a `DateInterval` instance via its `ttl` configuration option:
 
 ```php
+// default to the caching implementation's TTL for all renders
 $jahuty = new \Jahuty\Client('YOUR_API_KEY', ['cache' => $cache]);
 
-// cache this render for sixty seconds
-$render = $jahuty->snippets->render(1, ['ttl' => 60]);
+$render = $jahuty->snippets->render(1, [
+  'ttl' => 60  // <- except this render
+]);
 ```
+
+If a render's TTL is set, it will take precedence over the library's default TTL and the caching implementation's TTL.
 
 ### Disabling caching
 
@@ -143,14 +161,14 @@ You can disable caching, even the default in-memory caching, by passing a `ttl` 
 // disable all caching
 $jahuty1 = new \Jahuty\Client('YOUR_API_KEY', ['ttl' => 0]);
 
-$jahuty2 = new \Jahuty\Client('YOUR_API_KEY');
 // disable caching for this render
+$jahuty2 = new \Jahuty\Client('YOUR_API_KEY');
 $jahuty2->snippets->render(1, ['ttl' => 0]);
 ```
 
 ## Errors
 
-If [Jahuty's API](https://docs.jahuty.com/api) returns any status code other than `2xx`, a `Jahuty\Exception\Error` will be thrown:
+If Jahuty's API returns any [status code](https://docs.jahuty.com/api) other than `2xx`, a `Jahuty\Exception\Error` will be thrown:
 
 ```php
 try {

--- a/src/Cache/Manager.php
+++ b/src/Cache/Manager.php
@@ -5,7 +5,6 @@ namespace Jahuty\Cache;
 use Jahuty\Action\{Action, Show};
 use Jahuty\Client;
 use Jahuty\Resource\Resource;
-use Jahuty\Ttl\Ttl;
 use Psr\SimpleCache\CacheInterface as Cache;
 
 class Manager

--- a/src/Cache/Memory.php
+++ b/src/Cache/Memory.php
@@ -96,6 +96,8 @@ class Memory implements CacheInterface
             );
         }
 
+        // WARNING: Not supporting DateInterval is a break from the standard,
+        // but it seems acceptable as an internal tool.
         if ($ttl !== null && !\is_int($ttl)) {
             throw new InvalidArgumentException(
                 "Parameter three, ttl, must be null or int"

--- a/src/Cache/Ttl.php
+++ b/src/Cache/Ttl.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Jahuty\Ttl;
+namespace Jahuty\Cache;
 
 /**
- * The time between when an item is cached and when it is considered stale.
+ * A cache item's Time To Live (TTL) is the time between when an item is cached
+ * and when it's considered stale.
  *
- * According to PSR-16, there are several valid time-to-live values:
+ * According to PSR-16, there are several valid values:
  *
  *   a null value
  *     The implementing library may use a configured default duration, or

--- a/src/Client.php
+++ b/src/Client.php
@@ -43,7 +43,7 @@ class Client
         return $this->services->$name;
     }
 
-    public function fetch(Action\Action $action, Ttl\Ttl $ttl): Resource\Resource
+    public function fetch(Action\Action $action, Cache\Ttl $ttl): Resource\Resource
     {
         if (null === $this->cache) {
             $this->cache = new Cache\Manager(
@@ -107,7 +107,7 @@ class Client
         }
 
         // Accepts null, int, or DateInterval.
-        $options['ttl'] = new Ttl\Ttl($options['ttl']);
+        $options['ttl'] = new Cache\Ttl($options['ttl']);
 
         $this->options = $options;
     }

--- a/src/Jahuty.php
+++ b/src/Jahuty.php
@@ -6,5 +6,5 @@ class Jahuty
 {
     public const BASE_URI = 'https://api.jahuty.com';
 
-    public const VERSION = "5.1.0";
+    public const VERSION = "5.1.1";
 }

--- a/src/Service/Snippet.php
+++ b/src/Service/Snippet.php
@@ -4,7 +4,7 @@ namespace Jahuty\Service;
 
 use Jahuty\Action\Show;
 use Jahuty\Resource\Resource;
-use Jahuty\Ttl\Ttl;
+use Jahuty\Cache\Ttl;
 
 class Snippet extends Service
 {

--- a/tests/Cache/ManagerTest.php
+++ b/tests/Cache/ManagerTest.php
@@ -5,7 +5,6 @@ namespace Jahuty\Cache;
 use Jahuty\Action\Show;
 use Jahuty\Client;
 use Jahuty\Resource\Resource;
-use Jahuty\Ttl\Ttl;
 use Psr\SimpleCache\CacheInterface;
 
 class ManagerTest extends \PHPUnit\Framework\TestCase

--- a/tests/Cache/TtlTest.php
+++ b/tests/Cache/TtlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Jahuty\Ttl;
+namespace Jahuty\Cache;
 
 class TtlTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,8 +4,8 @@ namespace Jahuty;
 
 use donatj\MockWebServer\{MockWebServer, Response};
 use Jahuty\Action\Show;
+use Jahuty\Cache\Ttl;
 use Jahuty\Resource\Render;
-use Jahuty\Ttl\Ttl;
 use Psr\SimpleCache\CacheInterface;
 
 class ClientTest extends \PHPUnit\Framework\TestCase

--- a/tests/Service/SnippetTest.php
+++ b/tests/Service/SnippetTest.php
@@ -2,9 +2,9 @@
 
 namespace Jahuty\Service;
 
-use Jahuty\Client;
 use Jahuty\Action\Show;
-use Jahuty\Ttl\Ttl;
+use Jahuty\Cache\Ttl;
+use Jahuty\Client;
 
 class SnippetTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
Move the `Ttl` object from its own directory, where it's unlikely to ever have siblings, to the `Cache` directory where it is more intentional. Also, make a few changes to the README in the cache section to improve explanations.