### PR TITLE
Add dependency caching to builds and add circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,12 @@
 # Check https://circleci.com/docs/2.0/language-php/ for more details
 #
 version: 2.1
+
 orbs:
   codecov: codecov/codecov@1.1.3
+
 jobs:
-  build73:
+  test-73:
     docker:
       - image: circleci/php:7.3-node-browsers
     steps:
@@ -18,20 +20,21 @@ jobs:
       # Download and cache dependencies.
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "composer.json" }}
+            - v73-dependencies-{{ checksum "composer.json" }}
             # Fallback to using the latest cache if no exact match is found.
-            - v1-dependencies-
+            - v73-dependencies-
 
       - run: composer update --prefer-lowest --prefer-stable --no-interaction
 
       - save_cache:
-          key: v1-dependencies-{{ checksum "composer.json" }}
+          key: v73-dependencies-{{ checksum "composer.json" }}
           paths:
             - ./vendor
 
       - run: ./vendor/bin/phpcs .
       - run: ./vendor/bin/phpunit
-  build74:
+
+  test-74:
     docker:
       - image: circleci/php:7.4-node-browsers
     steps:
@@ -43,14 +46,21 @@ jobs:
       # Download and cache dependencies.
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "composer.json" }}
+            - v74-dependencies-{{ checksum "composer.json" }}
             # Fallback to using the latest cache if no exact match is found.
-            - v1-dependencies-
+            - v74-dependencies-
 
       - run: composer update --no-interaction
+
+      - save_cache:
+          key: v74-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+
       - run: ./vendor/bin/phpcs .
       - run: ./vendor/bin/phpunit
-  build8:
+
+  test-80:
     docker:
       - image: circleci/php:8.0-node-browsers
     steps:
@@ -62,13 +72,27 @@ jobs:
       # Download and cache dependencies.
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "composer.json" }}
+            - v80-dependencies-{{ checksum "composer.json" }}
             # Fallback to using the latest cache if no exact match is found.
-            - v1-dependencies-
+            - v80-dependencies-
 
       - run: composer update --no-interaction
+
+      - save_cache:
+          key: v80-dependencies-{{ checksum "composer.json" }}
+          paths:
+            - ./vendor
+
       - run: ./vendor/bin/phpcs .
       - run: XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
       - codecov/upload:
           file: ./coverage.xml
+
+workflows:
+  version: 2
+  test-php-versions:
+    jobs:
+      - test-73
+      - test-74
+      - test-80


### PR DESCRIPTION
Looks like CircleCi was confused by #23's changes to the config. 

```
#!/bin/sh -eo pipefail
# There are no workflows or build jobs in the config.
# 
# -------
# Warning: This configuration was auto-generated to show you the message above.
# Don't rerun this job. Rerunning will have no effect.
false

Exited with code exit status 1
CircleCI received exit code 1
```

I think I'm picking up what you're putting down, though, and I like it!

* I added dependency caching to each build (unless we dropped it intentionally); 
* I renamed the steps from `build73` to `test-73`; and,
* I added a `workflows` command, which CircleCI seemed to suggest in [this example](https://circleci.com/docs/2.0/sample-config/#sample-configuration-with-multiple-executor-types).