### PR TITLE
Add latest flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 .idea
 .project
 .phpunit.*
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.3.0 - 2020-04-27
+
+- Add the `prefer_latest_content` configuration setting to the client and render methods. This setting allows you to render a snippet's _latest_ content instead of the default _published_ content.
+
 ## 5.2.1 - 2020-03-16
 
 - Add system tests for collections, parameterized snippets, and problems.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It should be installed via [Composer](https://getcomposer.org). To do so, add th
 ```javascript
 {
    "require": {
-       "jahuty/jahuty-php": "^5.2"
+       "jahuty/jahuty-php": "^5.3"
    }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ foreach ($renders as $render) {
 }
 ```
 
+## Content versions
+
+Oftentimes, you'd like to render a snippet's _latest_ content in _development_ and its _published_ content in _production_.
+
+This library will render a snippet's _published_ content by default, but you can use the `prefer_latest_content` configuration option to render the _latest_ content instead:
+
+```php
+$jahuty = new \Jahuty\Client('YOUR_API_KEY', [
+  'prefer_latest_content' => true
+]);
+```
+
+You can also prefer the latest content (or not) for a single render:
+
+```php
+// Render the _published_ content for all snippets...
+$jahuty = new \Jahuty\Client('YOUR_API_KEY');
+
+// ... except, render the _latest_ content for this one.
+$render = $jahuty->snippets->render(YOUR_SNIPPET_ID, [
+  'prefer_latest_content' => true
+]);
+```
+
 ## Parameters
 
 You can [pass parameters](https://docs.jahuty.com/liquid/parameters) into your renders using the `params` key in the options associative array.

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,6 +19,8 @@ class Client
 
     private $cache;
 
+    private $preferLatestContent = false;
+
     private $requests;
 
     private $responses;
@@ -101,6 +103,13 @@ class Client
         return $this;
     }
 
+    public function setPreferLatestContent(bool $preferLatestContent): self
+    {
+        $this->preferLatestContent = $preferLatestContent;
+
+        return $this;
+    }
+
     public function setTtl($ttl): self
     {
         $this->cache = new Cache\Ttl($ttl);
@@ -119,6 +128,9 @@ class Client
      *   @option  int|DateTime  ttl  the default time-to-live when writing
      *     to the cache (optional; if omitted, uses the method's $ttl argument
      *     or the cache's default setting, in that order)
+     *   @option  bool  prefer_latest_content  a flag indicating whether or not
+     *     to prefer the latest content version (optional; if omitted, defaults
+     *     to published content version)
      * @return  void
      */
     private function unpackOptions(array $options): void
@@ -133,6 +145,10 @@ class Client
 
         if (isset($options['ttl'])) {
             $this->setTtl($options['ttl']);
+        }
+
+        if (isset($options['prefer_latest_content'])) {
+            $this->setPreferLatestContent($options['prefer_latest_content']);
         }
     }
 }

--- a/src/Jahuty.php
+++ b/src/Jahuty.php
@@ -6,5 +6,5 @@ class Jahuty
 {
     public const BASE_URI = 'https://api.jahuty.com';
 
-    public const VERSION = '5.2.1';
+    public const VERSION = '5.3.0';
 }

--- a/src/Service/Snippet.php
+++ b/src/Service/Snippet.php
@@ -33,6 +33,8 @@ class Snippet extends Service
      *   params: array  an array of parameters to pass to the renders, indexed
      *     by snippet id (use the "*" index to pass parameters to all snippets)
      *   ttl: int|DateTime  the time-to-live to use when writing to the cache
+     *   latest: bool  a flag indicating whether or not to render the latest
+     *     content version instead of the published version
      * }
      * @return  array
      */
@@ -40,12 +42,16 @@ class Snippet extends Service
     {
         [
             'ttl'    => $ttl,
-            'params' => $allParams
+            'params' => $allParams,
+            'latest' => $isLatest
         ] = $this->unpackOptions($options);
 
         $requestParams = ['tag' => $tag];
         if ($allParams) {
             $requestParams['params'] = $this->encode($allParams);
+        }
+        if ($isLatest) {
+            $requestParams['latest'] = 1;
         }
 
         $action = new Index('render', $requestParams);

--- a/src/Service/Snippet.php
+++ b/src/Service/Snippet.php
@@ -79,6 +79,8 @@ class Snippet extends Service
      * @param  array  $options {
      *   params: array  an array of parameters to pass to the render
      *   ttl: int|DateTime  the time-to-live to use when writing to the cache
+     *   latest: bool  a flag indicating whether or not to render the latest
+     *     content version instead of the published version
      * }
      * @return  Resource
      */
@@ -86,7 +88,8 @@ class Snippet extends Service
     {
         [
             'ttl'    => $ttl,
-            'params' => $renderParams
+            'params' => $renderParams,
+            'latest' => $isLatest
         ] = $this->unpackOptions($options);
 
         $cacheKey = $this->getCacheKey($snippetId, $renderParams);
@@ -98,6 +101,9 @@ class Snippet extends Service
         $requestParams = [];
         if ($renderParams) {
             $requestParams['params'] = $this->encode($renderParams);
+        }
+        if ($isLatest) {
+            $requestParams['latest'] = 1;
         }
 
         $action = new Show('render', $snippetId, $requestParams);
@@ -131,7 +137,8 @@ class Snippet extends Service
     {
         $defaults = [
             'params' => null,
-            'ttl'    => null
+            'ttl'    => null,
+            'latest' => false
         ];
 
         $results = \array_merge($defaults, $options);

--- a/src/Service/Snippet.php
+++ b/src/Service/Snippet.php
@@ -12,14 +12,21 @@ class Snippet extends Service
 {
     private $cache;
 
+    private $preferLatestContent;
+
     private $ttl;
 
-    public function __construct(Client $client, CacheInterface $cache, Ttl $ttl)
-    {
+    public function __construct(
+        Client $client,
+        CacheInterface $cache,
+        Ttl $ttl,
+        bool $preferLatestContent = false
+    ) {
         parent::__construct($client);
 
         $this->cache = $cache;
-        $this->ttl   = $ttl;
+        $this->ttl = $ttl;
+        $this->preferLatestContent = $preferLatestContent;
     }
 
     /**
@@ -43,14 +50,14 @@ class Snippet extends Service
         [
             'ttl'    => $ttl,
             'params' => $allParams,
-            'latest' => $isLatest
+            'latest' => $preferLatestContent
         ] = $this->unpackOptions($options);
 
         $requestParams = ['tag' => $tag];
         if ($allParams) {
             $requestParams['params'] = $this->encode($allParams);
         }
-        if ($isLatest) {
+        if ($preferLatestContent || $this->preferLatestContent) {
             $requestParams['latest'] = 1;
         }
 
@@ -95,7 +102,7 @@ class Snippet extends Service
         [
             'ttl'    => $ttl,
             'params' => $renderParams,
-            'latest' => $isLatest
+            'latest' => $preferLatestContent
         ] = $this->unpackOptions($options);
 
         $cacheKey = $this->getCacheKey($snippetId, $renderParams);
@@ -108,7 +115,7 @@ class Snippet extends Service
         if ($renderParams) {
             $requestParams['params'] = $this->encode($renderParams);
         }
-        if ($isLatest) {
+        if ($preferLatestContent || $this->preferLatestContent) {
             $requestParams['latest'] = 1;
         }
 

--- a/src/Service/Snippet.php
+++ b/src/Service/Snippet.php
@@ -40,17 +40,17 @@ class Snippet extends Service
      *   params: array  an array of parameters to pass to the renders, indexed
      *     by snippet id (use the "*" index to pass parameters to all snippets)
      *   ttl: int|DateTime  the time-to-live to use when writing to the cache
-     *   latest: bool  a flag indicating whether or not to render the latest
-     *     content version instead of the published version
+     *   prefer_latest_content: bool  a flag indicating whether or not to render
+     *     the latest content version instead of the published version
      * }
      * @return  array
      */
     public function allRenders(string $tag, array $options = []): array
     {
         [
-            'ttl'    => $ttl,
+            'ttl' => $ttl,
             'params' => $allParams,
-            'latest' => $preferLatestContent
+            'prefer_latest_content' => $preferLatestContent
         ] = $this->unpackOptions($options);
 
         $requestParams = ['tag' => $tag];
@@ -92,17 +92,17 @@ class Snippet extends Service
      * @param  array  $options {
      *   params: array  an array of parameters to pass to the render
      *   ttl: int|DateTime  the time-to-live to use when writing to the cache
-     *   latest: bool  a flag indicating whether or not to render the latest
-     *     content version instead of the published version
+     *   prefer_latest_content: bool  a flag indicating whether or not to render
+     *     the latest content version instead of the published version
      * }
      * @return  Resource
      */
     public function render(int $snippetId, array $options = []): Resource
     {
         [
-            'ttl'    => $ttl,
+            'ttl' => $ttl,
             'params' => $renderParams,
-            'latest' => $preferLatestContent
+            'prefer_latest_content' => $preferLatestContent
         ] = $this->unpackOptions($options);
 
         $cacheKey = $this->getCacheKey($snippetId, $renderParams);
@@ -150,8 +150,8 @@ class Snippet extends Service
     {
         $defaults = [
             'params' => null,
-            'ttl'    => null,
-            'latest' => false
+            'ttl' => null,
+            'prefer_latest_content' => false
         ];
 
         $results = \array_merge($defaults, $options);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -102,6 +102,13 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($client, $client->setCache($cache));
     }
 
+    public function testSetPreferLatestContent(): void
+    {
+        $client = new Client('foo');
+
+        $this->assertSame($client, $client->setPreferLatestContent(true));
+    }
+
     public function testSetTtl(): void
     {
         $client = new Client('foo');

--- a/tests/Service/SnippetTest.php
+++ b/tests/Service/SnippetTest.php
@@ -69,7 +69,7 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
 
     public function testRendersWithLatest(): void
     {
-        // the expected action, note the json-encoded params)
+        // the expected action
         $action = new Index('render', ['tag' => 'foo', 'latest' => 1]);
 
         // a no-op cache
@@ -83,7 +83,9 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
 
         $service = new Snippet($client, $cache, new Ttl());
 
-        $service->allRenders('foo', ['latest' => true]);
+        $service->allRenders('foo', [
+            'prefer_latest_content' => true
+        ]);
     }
 
     public function testRenderReturnsRenderWhenCacheMiss(): void
@@ -202,6 +204,6 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
 
         $service = new Snippet($client, $cache, new Ttl());
 
-        $service->render(1, ['latest' => true]);
+        $service->render(1, ['prefer_latest_content' => true]);
     }
 }

--- a/tests/Service/SnippetTest.php
+++ b/tests/Service/SnippetTest.php
@@ -163,4 +163,26 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
 
         $service->render(1, ['ttl' => $ttl]);
     }
+
+    public function testRenderWhenLatestExists(): void
+    {
+        // the expected action
+        $action = new Show('render', 1, ['latest' => 1]);
+
+        // the render to return
+        $render = new Render(1, 'foo');
+
+        // a cache miss
+        $cache = $this->createMock(CacheInterface::class);
+
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('request')
+            ->with($this->equalTo($action))
+            ->will($this->returnValue($render));
+
+        $service = new Snippet($client, $cache, new Ttl());
+
+        $service->render(1, ['latest' => true]);
+    }
 }

--- a/tests/Service/SnippetTest.php
+++ b/tests/Service/SnippetTest.php
@@ -67,6 +67,25 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
+    public function testRendersWithLatest(): void
+    {
+        // the expected action, note the json-encoded params)
+        $action = new Index('render', ['tag' => 'foo', 'latest' => 1]);
+
+        // a no-op cache
+        $cache = $this->createMock(CacheInterface::class);
+
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('request')
+            ->with($this->equalTo($action))
+            ->will($this->returnValue([]));
+
+        $service = new Snippet($client, $cache, new Ttl());
+
+        $service->allRenders('foo', ['latest' => true]);
+    }
+
     public function testRenderReturnsRenderWhenCacheMiss(): void
     {
         // the action to request

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -62,7 +62,7 @@ class SystemTest extends \PHPUnit\Framework\TestCase
     public function testAllRendersWithLatest(): void
     {
         $renders = $this->jahuty->snippets->allRenders('test', [
-            'latest' => true
+            'prefer_latest_content' => true
         ]);
 
         $last = end($renders);
@@ -127,7 +127,9 @@ class SystemTest extends \PHPUnit\Framework\TestCase
 
     public function testRenderWithLatest(): void
     {
-        $render = $this->jahuty->snippets->render(102, ['latest' => true]);
+        $render = $this->jahuty->snippets->render(102, [
+            'prefer_latest_content' => true
+        ]);
 
         $this->assertEquals(
             '<p>This content is latest.</p>',

--- a/tests/SystemTest.php
+++ b/tests/SystemTest.php
@@ -22,7 +22,6 @@ class SystemTest extends \PHPUnit\Framework\TestCase
             ]
         ]);
 
-        $this->assertCount(2, $renders);
         $this->assertContainsOnlyInstancesOf(Resource\Render::class, $renders);
 
         // Rendering a snippet in the collection using the _same_ parameters
@@ -58,6 +57,20 @@ class SystemTest extends \PHPUnit\Framework\TestCase
         $actual  = ($end - $start) * 1000;
 
         $this->assertGreaterThan($minimum, $actual);
+    }
+
+    public function testAllRendersWithLatest(): void
+    {
+        $renders = $this->jahuty->snippets->allRenders('test', [
+            'latest' => true
+        ]);
+
+        $last = end($renders);
+
+        $this->assertEquals(
+            '<p>This content is latest.</p>',
+            $last->getContent()
+        );
     }
 
     public function testRenderWithoutParameters(): void
@@ -110,6 +123,16 @@ class SystemTest extends \PHPUnit\Framework\TestCase
         $actual  = ($end - $start) * 1000;
 
         $this->assertGreaterThan($minimum, $actual);
+    }
+
+    public function testRenderWithLatest(): void
+    {
+        $render = $this->jahuty->snippets->render(102, ['latest' => true]);
+
+        $this->assertEquals(
+            '<p>This content is latest.</p>',
+            $render->getContent()
+        );
     }
 
     public function testProblem(): void


### PR DESCRIPTION
Add support for the API's new `latest` flag with `prefer_latest_content` configuration option.