### PR TITLE
Deprecate prefer_latest_content param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - A `location` option to the `render` method, which allows you to report the absolute URL where the snippet is being rendered.
+- The `prefer_latest` configuration option, a similarly intentional but shorter version of the `prefer_latest_content` configuration option.
+
+### Changed
+
+- Deprecated `prefer_latest_content` configuration option in favor `prefer_latest`.
 
 ## 5.3.0 - 2020-04-27
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,7 +19,7 @@ class Client
 
     private $cache;
 
-    private $preferLatestContent = false;
+    private $preferLatest = false;
 
     private $requests;
 
@@ -49,7 +49,8 @@ class Client
             $this->services[$name] = new Service\Snippet(
                 $this,
                 $this->cache,
-                $this->ttl
+                $this->ttl,
+                $this->preferLatest
             );
         }
 
@@ -103,9 +104,17 @@ class Client
         return $this;
     }
 
+    /**
+     * @deprecated  use preferLatest() instead (2020-07-28)
+     */
     public function setPreferLatestContent(bool $preferLatestContent): self
     {
-        $this->preferLatestContent = $preferLatestContent;
+        return $this->setPreferLatest($preferLatestContent);
+    }
+
+    public function setPreferLatest(bool $preferLatest): self
+    {
+        $this->preferLatest = $preferLatest;
 
         return $this;
     }
@@ -130,6 +139,9 @@ class Client
      *     or the cache's default setting, in that order)
      *   @option  bool  prefer_latest_content  a flag indicating whether or not
      *     to prefer the latest content version (optional; if omitted, defaults
+     *     to published content version) (deprecated)
+     *   @option  bool  prefer_latest  a flag indicating whether or not to
+     *     prefer the latest content version (optional; if omitted, defaults
      *     to published content version)
      * @return  void
      */
@@ -147,8 +159,8 @@ class Client
             $this->setTtl($options['ttl']);
         }
 
-        if (isset($options['prefer_latest_content'])) {
-            $this->setPreferLatestContent($options['prefer_latest_content']);
+        if (isset($options['prefer_latest_content']) || isset($options['prefer_latest'])) {
+            $this->setPreferLatest($options['prefer_latest_content'] || $options['prefer_latest']);
         }
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -109,6 +109,13 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($client, $client->setPreferLatestContent(true));
     }
 
+    public function testSetPreferLatest(): void
+    {
+        $client = new Client('foo');
+
+        $this->assertSame($client, $client->setPreferLatest(true));
+    }
+
     public function testSetTtl(): void
     {
         $client = new Client('foo');

--- a/tests/Service/SnippetTest.php
+++ b/tests/Service/SnippetTest.php
@@ -67,7 +67,7 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testAllRendersWithLatest(): void
+    public function testAllRendersWithLatestDeprecated(): void
     {
         // the expected action
         $action = new Index('render', ['tag' => 'foo', 'latest' => 1]);
@@ -86,6 +86,25 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
         $service->allRenders('foo', [
             'prefer_latest_content' => true
         ]);
+    }
+
+    public function testAllRendersWithLatest(): void
+    {
+        // the expected action
+        $action = new Index('render', ['tag' => 'foo', 'latest' => 1]);
+
+        // a no-op cache
+        $cache = $this->createMock(CacheInterface::class);
+
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('request')
+            ->with($this->equalTo($action))
+            ->will($this->returnValue([]));
+
+        $service = new Snippet($client, $cache, new Ttl());
+
+        $service->allRenders('foo', ['prefer_latest' => true]);
     }
 
     public function testRenderWithCacheMiss(): void
@@ -185,7 +204,7 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
         $service->render(1, ['ttl' => $ttl]);
     }
 
-    public function testRenderWithLatest(): void
+    public function testRenderWithLatestDeprecated(): void
     {
         // the expected action
         $action = new Show('render', 1, ['latest' => 1]);
@@ -205,6 +224,28 @@ class SnippetTest extends \PHPUnit\Framework\TestCase
         $service = new Snippet($client, $cache, new Ttl());
 
         $service->render(1, ['prefer_latest_content' => true]);
+    }
+
+    public function testRenderWithLatest(): void
+    {
+        // the expected action
+        $action = new Show('render', 1, ['latest' => 1]);
+
+        // the render to return
+        $render = new Render(1, 'foo');
+
+        // a cache miss
+        $cache = $this->createMock(CacheInterface::class);
+
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('request')
+            ->with($this->equalTo($action))
+            ->will($this->returnValue($render));
+
+        $service = new Snippet($client, $cache, new Ttl());
+
+        $service->render(1, ['prefer_latest' => true]);
     }
 
     public function testRenderWithLocation(): void


### PR DESCRIPTION
Deprecate the `prefer_latest_content` configuration option in favor of the similarly intentional but short `prefer_latest` configuration option.

Closes #28 